### PR TITLE
feat(core): add persistent transactions, dashboard totals, and transaction list

### DIFF
--- a/App.js
+++ b/App.js
@@ -2,7 +2,7 @@
 import 'react-native-gesture-handler';
 import 'react-native-reanimated';
 
-import * as React from 'react';
+import React from 'react';
 import { StatusBar, View, Appearance } from 'react-native';
 import { LinearGradient } from 'expo-linear-gradient';
 import {
@@ -13,27 +13,21 @@ import { NavigationContainer } from '@react-navigation/native';
 import { createNativeStackNavigator } from '@react-navigation/native-stack';
 import { SafeAreaProvider } from 'react-native-safe-area-context';
 
-<<<<<<< HEAD
-=======
 try {
   require('./app/config.local');
 } catch {
   // Optional local overrides for development only
 }
 
->>>>>>> 53fbc4eaf50aa56101b353f9eb128c405a27dff9
 import { useColors, radii } from './app/lib/theme';
+import { TransactionsProvider } from './app/lib/transactions';
 
 import SignIn from './app/screens/SignIn';
 import SignUp from './app/screens/SignUp';
 import AppLock from './app/screens/AppLock';
 import RootTabs from './app/navigation/RootTabs';
 import LinkBank from './app/screens/LinkBank';
-
-// Optional local config (silently ignored if missing)
-try {
-  require('./app/config.local');
-} catch {}
+import AddTransaction from './app/screens/AddTransaction';
 
 const Stack = createNativeStackNavigator();
 
@@ -49,10 +43,10 @@ export default function App() {
     roundness: radii.md,
     colors: {
       ...DefaultTheme.colors,
-      primary: colors.primary,    // accent color from theme
+      primary: colors.primary,
       onSurface: colors.text,
       surface: 'transparent',
-      background: colors.background,
+      background: colors.background ?? colors.bg,
     },
   };
 
@@ -68,38 +62,35 @@ export default function App() {
 
   return (
     <SafeAreaProvider>
-      <PaperProvider theme={theme}>
-        <StatusBar barStyle={barStyle} backgroundColor="transparent" translucent />
+      <TransactionsProvider>
+        <PaperProvider theme={theme}>
+          <StatusBar barStyle={barStyle} backgroundColor="transparent" translucent />
 
-        <LinearGradient
-          colors={gradient}
-          start={{ x: 0, y: 0 }}
-          end={{ x: 1, y: 1 }}
-          style={{ flex: 1 }}
-        >
-          <View
-            style={{ flex: 1, backgroundColor: `${bgSecondary}AA` }}
-            accessibilityRole="summary"
-            accessibilityLabel="Premium neon backdrop"
+          <LinearGradient
+            colors={gradient}
+            start={{ x: 0, y: 0 }}
+            end={{ x: 1, y: 1 }}
+            style={{ flex: 1 }}
           >
-            <NavigationContainer>
-<<<<<<< HEAD
-              <Stack.Navigator
-                screenOptions={{ headerShown: false, animation: 'fade_from_bottom' }}
-              >
-=======
-              <Stack.Navigator screenOptions={{ headerShown: false, animation: 'fade_from_bottom' }}>
->>>>>>> 53fbc4eaf50aa56101b353f9eb128c405a27dff9
-                <Stack.Screen name="SignIn" component={SignIn} />
-                <Stack.Screen name="SignUp" component={SignUp} />
-                <Stack.Screen name="AppLock" component={AppLock} />
-                <Stack.Screen name="RootTabs" component={RootTabs} />
-                <Stack.Screen name="LinkBank" component={LinkBank} />
-              </Stack.Navigator>
-            </NavigationContainer>
-          </View>
-        </LinearGradient>
-      </PaperProvider>
+            <View
+              style={{ flex: 1, backgroundColor: `${bgSecondary}AA` }}
+              accessibilityRole="summary"
+              accessibilityLabel="Premium neon backdrop"
+            >
+              <NavigationContainer>
+                <Stack.Navigator screenOptions={{ headerShown: false, animation: 'fade_from_bottom' }}>
+                  <Stack.Screen name="SignIn" component={SignIn} />
+                  <Stack.Screen name="SignUp" component={SignUp} />
+                  <Stack.Screen name="AppLock" component={AppLock} />
+                  <Stack.Screen name="RootTabs" component={RootTabs} />
+                  <Stack.Screen name="LinkBank" component={LinkBank} />
+                  <Stack.Screen name="AddTransaction" component={AddTransaction} />
+                </Stack.Navigator>
+              </NavigationContainer>
+            </View>
+          </LinearGradient>
+        </PaperProvider>
+      </TransactionsProvider>
     </SafeAreaProvider>
   );
 }

--- a/__tests__/sanity.test.js
+++ b/__tests__/sanity.test.js
@@ -1,5 +1,6 @@
-describe('sanity check', () => {
-  it('confirms the test runner works', () => {
-    expect(true).toBe(true);
-  });
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+test('sanity check', () => {
+  assert.equal(true, true);
 });

--- a/app/components/AnimatedNumber.js
+++ b/app/components/AnimatedNumber.js
@@ -3,27 +3,31 @@ import { useEffect } from 'react';
 import { Text } from 'react-native';
 import Animated, { useSharedValue, withTiming, useAnimatedProps } from 'react-native-reanimated';
 
-// Helper to format as currency
-const formatMoney = (n) =>
-  (n || 0).toLocaleString('en-US', { style: 'currency', currency: 'USD', maximumFractionDigits: 0 });
+const formatMoney = (n, precision) => {
+  'worklet';
+  return (n || 0).toLocaleString('en-US', {
+    style: 'currency',
+    currency: 'USD',
+    minimumFractionDigits: precision,
+    maximumFractionDigits: precision,
+  });
+};
 
 const AnimatedText = Animated.createAnimatedComponent(Text);
 
-export default function AnimatedNumber({ value = 0, duration = 1200, style }) {
+export default function AnimatedNumber({ value = 0, duration = 1200, precision = 0, style }) {
   const progress = useSharedValue(0);
 
   useEffect(() => {
-    // animate from 0 to 1 for each new value
     progress.value = 0;
     progress.value = withTiming(1, { duration });
   }, [duration, progress, value]);
 
   const animatedProps = useAnimatedProps(() => {
-    // simple ease: 0..1 → 0..value
-    const current = Math.round(progress.value * value);
-    return { text: formatMoney(current) };
+    const current = progress.value * value;
+    return { text: formatMoney(current, precision) };
   });
 
   // @ts-ignore: AnimatedText supports animatedProps.text
-  return <AnimatedText style={style} animatedProps={animatedProps} />;
+  return <AnimatedText style={style} animatedProps={animatedProps} accessibilityRole="text" allowFontScaling />;
 }

--- a/app/components/TransactionList.js
+++ b/app/components/TransactionList.js
@@ -1,0 +1,173 @@
+import { useMemo, useRef } from 'react';
+import { Alert, FlatList, View } from 'react-native';
+import { Text, ActivityIndicator } from 'react-native-paper';
+import { Swipeable } from 'react-native-gesture-handler';
+import * as Haptics from 'expo-haptics';
+import GlassCard from './GlassCard';
+import { useColors, spacing, radii } from '../lib/theme';
+
+const formatCurrency = (value) => {
+  return Number(value || 0).toLocaleString('en-US', {
+    style: 'currency',
+    currency: 'USD',
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
+  });
+};
+
+const formatDate = (value) => {
+  const parsed = new Date(value);
+  if (Number.isNaN(parsed.getTime())) {
+    return '';
+  }
+  return parsed.toLocaleDateString(undefined, {
+    month: 'short',
+    day: 'numeric',
+    year: 'numeric',
+  });
+};
+
+export default function TransactionList({ transactions = [], loading, onDelete, style }) {
+  const colors = useColors();
+  const swipeRefs = useRef({});
+
+  const sorted = useMemo(() => {
+    return [...transactions].sort((a, b) => new Date(b.date) - new Date(a.date));
+  }, [transactions]);
+
+  const closeSwipe = (id) => {
+    const ref = swipeRefs.current[id];
+    ref?.close();
+  };
+
+  const confirmDelete = (item) => {
+    Haptics.notificationAsync(Haptics.NotificationFeedbackType.Warning).catch(() => {});
+    Alert.alert(
+      'Delete transaction',
+      `Remove ${item.title}?`,
+      [
+        {
+          text: 'Cancel',
+          style: 'cancel',
+          onPress: () => closeSwipe(item.id),
+        },
+        {
+          text: 'Delete',
+          style: 'destructive',
+          onPress: async () => {
+            try {
+              await onDelete?.(item.id);
+            } catch (error) {
+              if (__DEV__) {
+                console.warn('Failed to delete transaction', error);
+              }
+              Alert.alert('Delete failed', 'We could not remove that transaction. Please try again.');
+            } finally {
+              closeSwipe(item.id);
+            }
+          },
+        },
+      ],
+      { cancelable: true },
+    );
+  };
+
+  const renderRightActions = () => (
+    <View style={{ flex: 1, justifyContent: 'center', alignItems: 'flex-end' }}>
+      <View
+        style={{
+          backgroundColor: colors.danger,
+          justifyContent: 'center',
+          alignItems: 'center',
+          paddingHorizontal: spacing(2),
+          paddingVertical: spacing(1),
+          borderRadius: radii.lg,
+          marginVertical: spacing(0.5),
+          marginRight: spacing(1),
+          minWidth: spacing(9),
+        }}
+      >
+        <Text style={{ color: '#fff', fontWeight: '700' }}>Delete</Text>
+      </View>
+    </View>
+  );
+
+  const renderItem = ({ item }) => {
+    const amountColor = item.type === 'income' ? colors.success : colors.danger;
+    const symbol = item.type === 'income' ? '+' : '-';
+    return (
+      <Swipeable
+        ref={(ref) => {
+          if (ref) {
+            swipeRefs.current[item.id] = ref;
+          } else {
+            delete swipeRefs.current[item.id];
+          }
+        }}
+        friction={2}
+        rightThreshold={spacing(4)}
+        overshootRight={false}
+        renderRightActions={renderRightActions}
+        onSwipeableOpen={(direction) => {
+          if (direction === 'right') {
+            confirmDelete(item);
+          }
+        }}
+      >
+        <View
+          style={{
+            flexDirection: 'row',
+            justifyContent: 'space-between',
+            alignItems: 'center',
+            paddingVertical: spacing(1.5),
+            paddingHorizontal: spacing(1),
+            borderBottomWidth: 1,
+            borderBottomColor: colors.divider,
+          }}
+          accessible
+          accessibilityRole="summary"
+          accessibilityLabel={`${item.title}, ${formatCurrency(item.amount)} ${item.type}, ${formatDate(item.date)}`}
+        >
+          <View style={{ flex: 1, paddingRight: spacing(1) }}>
+            <Text style={{ color: colors.text, fontWeight: '600' }}>{item.title}</Text>
+            <Text style={{ color: colors.subtext, marginTop: 2 }}>
+              {formatDate(item.date)} · {item.category}
+            </Text>
+          </View>
+          <Text style={{ color: amountColor, fontWeight: '700' }}>
+            {`${symbol}${formatCurrency(item.amount)}`}
+          </Text>
+        </View>
+      </Swipeable>
+    );
+  };
+
+  return (
+    <GlassCard
+      style={style}
+      accessibilityLabel="Transaction history"
+      accessibilityRole="summary"
+    >
+      <Text style={{ color: colors.text, fontWeight: '700', marginBottom: spacing(1) }}>
+        Recent transactions
+      </Text>
+      {loading ? (
+        <View style={{ paddingVertical: spacing(3), alignItems: 'center' }}>
+          <ActivityIndicator animating color={colors.accent1} accessibilityLabel="Loading transactions" />
+        </View>
+      ) : sorted.length === 0 ? (
+        <Text style={{ color: colors.subtext }}>
+          Add your first transaction to unlock personalized insights.
+        </Text>
+      ) : (
+        <FlatList
+          data={sorted}
+          keyExtractor={(item) => item.id}
+          renderItem={renderItem}
+          scrollEnabled={false}
+          contentContainerStyle={{ paddingHorizontal: spacing(1) }}
+        />
+      )}
+    </GlassCard>
+  );
+}

--- a/app/lib/theme.js
+++ b/app/lib/theme.js
@@ -5,29 +5,57 @@ export const spacing = (factor = 1) => factor * 8; // 8px grid system
 export const radii = {
   sm: 6,
   md: 12,
-  lg: 24,
+  lg: 20,
+  xl: 28,
 };
 
 export const useIsDarkMode = () => {
   return Appearance.getColorScheme() === 'dark';
 };
 
+const lightPalette = {
+  bg: '#F5F7FB',
+  bgSecondary: '#E7ECF5',
+  background: '#F5F7FB',
+  bgGradient: ['#f7f8fc', '#eef2fb', '#e3e7f5'],
+  card: 'rgba(255,255,255,0.75)',
+  cardBorder: 'rgba(255,255,255,0.55)',
+  cardOutline: 'rgba(255,255,255,0.92)',
+  divider: 'rgba(15,23,42,0.08)',
+  text: '#101828',
+  subtext: '#475467',
+  accent1: '#A18CFF',
+  accent2: '#58D5F7',
+  accent3: '#52FFC5',
+  success: '#12B76A',
+  danger: '#F04438',
+  menuBackground: 'rgba(255,255,255,0.95)',
+  segmentBackground: 'rgba(15,23,42,0.08)',
+  primary: '#A18CFF',
+};
+
+const darkPalette = {
+  bg: '#050510',
+  bgSecondary: '#10111F',
+  background: '#050510',
+  bgGradient: ['#03030a', '#09091a', '#111226'],
+  card: 'rgba(15,15,25,0.78)',
+  cardBorder: 'rgba(120,121,255,0.22)',
+  cardOutline: 'rgba(255,255,255,0.08)',
+  divider: 'rgba(255,255,255,0.08)',
+  text: '#EEF2FF',
+  subtext: '#B8C2EE',
+  accent1: '#8C7CFF',
+  accent2: '#4FC9F4',
+  accent3: '#52FFC5',
+  success: '#4ADE80',
+  danger: '#F87171',
+  menuBackground: 'rgba(21,22,36,0.96)',
+  segmentBackground: 'rgba(255,255,255,0.08)',
+  primary: '#8C7CFF',
+};
+
 export const useColors = () => {
   const isDark = useIsDarkMode();
-
-  return {
-    // Backgrounds
-    bg: isDark ? '#000000' : '#FFFFFF',
-    bgSecondary: isDark ? '#121212' : '#F2F2F7',
-    bgGradient: isDark
-      ? ['#0f0f0f', '#1a1a1a', '#222831']
-      : ['#ffffff', '#f4f4f4', '#eaeaea'],
-
-    // Text
-    text: isDark ? '#EAEAEA' : '#1A1A1A',
-
-    // Accent
-    accent1: '#A18CFF', // purple gradient
-    accent2: '#58D5F7', // blue gradient
-  };
+  return isDark ? darkPalette : lightPalette;
 };

--- a/app/lib/transactions.js
+++ b/app/lib/transactions.js
@@ -1,0 +1,162 @@
+import { createContext, useCallback, useContext, useEffect, useMemo, useRef, useState } from 'react';
+import { Alert } from 'react-native';
+import AsyncStorage from '@react-native-async-storage/async-storage';
+
+const STORAGE_KEY = '@hustleledger/transactions';
+
+const TransactionsContext = createContext(null);
+
+const normalizeTransaction = (input) => {
+  const safeAmount = Number.parseFloat(String(input?.amount ?? 0));
+  const amount = Number.isNaN(safeAmount) ? 0 : safeAmount;
+  const type = input?.type === 'income' ? 'income' : 'expense';
+  const date = input?.date ? new Date(input.date).toISOString() : new Date().toISOString();
+
+  return {
+    id: String(input?.id ?? `${Date.now()}-${Math.random().toString(16).slice(2)}`),
+    title: String(input?.title ?? '').trim() || 'Untitled',
+    amount,
+    type,
+    date,
+    category: String(input?.category ?? '').trim() || 'General',
+  };
+};
+
+export function TransactionsProvider({ children }) {
+  const [transactions, setTransactions] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
+  const isMountedRef = useRef(true);
+  const transactionsRef = useRef([]);
+
+  useEffect(() => {
+    transactionsRef.current = transactions;
+  }, [transactions]);
+
+  useEffect(() => {
+    return () => {
+      isMountedRef.current = false;
+    };
+  }, []);
+
+  const persistTransactions = useCallback(async (next) => {
+    try {
+      await AsyncStorage.setItem(STORAGE_KEY, JSON.stringify(next));
+      setError(null);
+    } catch (err) {
+      if (__DEV__) {
+        console.warn('Failed to persist transactions', err);
+      }
+      setError('We could not save your transactions.');
+      Alert.alert('Save failed', 'We could not store your transactions. Please try again.');
+      throw err;
+    }
+  }, []);
+
+  const loadTransactions = useCallback(async () => {
+    try {
+      const raw = await AsyncStorage.getItem(STORAGE_KEY);
+      if (!isMountedRef.current) {
+        return;
+      }
+      if (raw) {
+        try {
+          const parsed = JSON.parse(raw);
+          if (Array.isArray(parsed)) {
+            const normalized = parsed.map((item) => normalizeTransaction(item));
+            normalized.sort((a, b) => new Date(b.date) - new Date(a.date));
+            transactionsRef.current = normalized;
+            setTransactions(normalized);
+          } else {
+            transactionsRef.current = [];
+            setTransactions([]);
+          }
+        } catch (parseError) {
+          if (__DEV__) {
+            console.warn('Invalid transactions payload in storage', parseError);
+          }
+          transactionsRef.current = [];
+          setTransactions([]);
+        }
+      } else {
+        transactionsRef.current = [];
+        setTransactions([]);
+      }
+      setError(null);
+    } catch (err) {
+      if (__DEV__) {
+        console.warn('Failed to load transactions', err);
+      }
+      setError('We could not load your transactions.');
+    } finally {
+      if (isMountedRef.current) {
+        setLoading(false);
+      }
+    }
+  }, []);
+
+  useEffect(() => {
+    loadTransactions();
+  }, [loadTransactions]);
+
+  const addTransaction = useCallback(
+    async ({ title, amount, category, type, date }) => {
+      const transaction = normalizeTransaction({ title, amount, category, type, date });
+      const previous = transactionsRef.current;
+      const next = [transaction, ...previous];
+      transactionsRef.current = next;
+      setTransactions(next);
+      try {
+        await persistTransactions(next);
+      } catch (err) {
+        if (isMountedRef.current) {
+          transactionsRef.current = previous;
+          setTransactions(previous);
+        }
+        throw err;
+      }
+    },
+    [persistTransactions],
+  );
+
+  const deleteTransaction = useCallback(
+    async (id) => {
+      const previous = transactionsRef.current;
+      const next = previous.filter((item) => item.id !== id);
+      transactionsRef.current = next;
+      setTransactions(next);
+      try {
+        await persistTransactions(next);
+      } catch (err) {
+        if (isMountedRef.current) {
+          transactionsRef.current = previous;
+          setTransactions(previous);
+        }
+        throw err;
+      }
+    },
+    [persistTransactions],
+  );
+
+  const value = useMemo(
+    () => ({
+      transactions,
+      loading,
+      error,
+      addTransaction,
+      deleteTransaction,
+      refresh: loadTransactions,
+    }),
+    [transactions, loading, error, addTransaction, deleteTransaction, loadTransactions],
+  );
+
+  return <TransactionsContext.Provider value={value}>{children}</TransactionsContext.Provider>;
+}
+
+export const useTransactions = () => {
+  const context = useContext(TransactionsContext);
+  if (!context) {
+    throw new Error('useTransactions must be used within a TransactionsProvider');
+  }
+  return context;
+};

--- a/app/screens/AddTransaction.js
+++ b/app/screens/AddTransaction.js
@@ -1,0 +1,201 @@
+import { useState } from 'react';
+import { KeyboardAvoidingView, Platform, ScrollView, View } from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
+import { TextInput, Text, HelperText, Button, Menu, SegmentedButtons } from 'react-native-paper';
+import GlassCard from '../components/GlassCard';
+import HLButton from '../components/HLButton';
+import { useColors, spacing, radii } from '../lib/theme';
+import { useTransactions } from '../lib/transactions';
+
+const CATEGORY_OPTIONS = [
+  'Side Hustle',
+  'Dining',
+  'Transportation',
+  'Housing',
+  'Savings',
+  'Investments',
+  'Wellness',
+  'Other',
+];
+
+export default function AddTransaction({ navigation }) {
+  const colors = useColors();
+  const { addTransaction } = useTransactions();
+  const [title, setTitle] = useState('');
+  const [amount, setAmount] = useState('');
+  const [category, setCategory] = useState(CATEGORY_OPTIONS[0]);
+  const [type, setType] = useState('income');
+  const [menuVisible, setMenuVisible] = useState(false);
+  const [error, setError] = useState('');
+  const [submitting, setSubmitting] = useState(false);
+
+  const handleSubmit = async () => {
+    setError('');
+    const trimmedTitle = title.trim();
+    const numericAmount = Number.parseFloat(amount);
+
+    if (!trimmedTitle) {
+      setError('A title keeps the transaction recognizable.');
+      return;
+    }
+
+    if (Number.isNaN(numericAmount) || numericAmount <= 0) {
+      setError('Enter an amount greater than zero.');
+      return;
+    }
+
+    setSubmitting(true);
+    try {
+      await addTransaction({
+        title: trimmedTitle,
+        amount: numericAmount,
+        category,
+        type,
+        date: new Date().toISOString(),
+      });
+      navigation.goBack();
+    } catch (error) {
+      if (__DEV__) {
+        console.warn('Failed to save transaction', error);
+      }
+      setError('We could not save your transaction. Please try again.');
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <KeyboardAvoidingView
+      style={{ flex: 1 }}
+      behavior={Platform.OS === 'ios' ? 'padding' : undefined}
+    >
+      <SafeAreaView style={{ flex: 1 }}>
+        <ScrollView
+          contentContainerStyle={{ padding: spacing(2), paddingBottom: spacing(6) }}
+          keyboardShouldPersistTaps="handled"
+        >
+          <View style={{ marginBottom: spacing(2) }}>
+            <Text
+              variant="labelLarge"
+              style={{
+                color: colors.accent3,
+                alignSelf: 'flex-start',
+                backgroundColor: colors.accent3 + '14',
+                borderRadius: radii.lg,
+                paddingHorizontal: spacing(1.5),
+                paddingVertical: spacing(0.5),
+                fontWeight: '600',
+              }}
+              accessibilityRole="text"
+            >
+              Cashflow log
+            </Text>
+            <Text
+              variant="headlineMedium"
+              style={{ color: colors.text, fontWeight: '800', marginTop: spacing(1.5) }}
+              accessibilityRole="header"
+            >
+              Add a transaction
+            </Text>
+            <Text style={{ color: colors.subtext, marginTop: spacing(1), lineHeight: 20 }}>
+              Track wins and expenses the moment they land. HustleLedger updates your dashboard instantly.
+            </Text>
+          </View>
+
+          <GlassCard accessibilityLabel="Add a new transaction" accessibilityRole="form">
+            <TextInput
+              label="Title"
+              value={title}
+              onChangeText={setTitle}
+              autoCapitalize="words"
+              style={{ marginBottom: spacing(1.5), backgroundColor: 'transparent' }}
+              mode="flat"
+              theme={{ colors: { onSurfaceVariant: colors.subtext, primary: colors.accent1 } }}
+              accessibilityLabel="Transaction title"
+            />
+
+            <TextInput
+              label="Amount"
+              value={amount}
+              onChangeText={setAmount}
+              keyboardType={Platform.select({ ios: 'decimal-pad', default: 'numeric' })}
+              style={{ marginBottom: spacing(1.5), backgroundColor: 'transparent' }}
+              mode="flat"
+              theme={{ colors: { onSurfaceVariant: colors.subtext, primary: colors.accent1 } }}
+              accessibilityLabel="Transaction amount"
+            />
+
+            <View style={{ marginBottom: spacing(1.5) }}>
+              <Menu
+                visible={menuVisible}
+                onDismiss={() => setMenuVisible(false)}
+                anchorPosition="bottom"
+                contentStyle={{ backgroundColor: colors.menuBackground, borderRadius: radii.md }}
+                anchor={
+                  <Button
+                    mode="outlined"
+                    onPress={() => setMenuVisible(true)}
+                    textColor={colors.text}
+                    style={{
+                      borderColor: colors.cardBorder,
+                      borderRadius: radii.lg,
+                    }}
+                    accessibilityLabel="Choose a category"
+                  >
+                    {category}
+                  </Button>
+                }
+              >
+                {CATEGORY_OPTIONS.map((option) => (
+                  <Menu.Item
+                    key={option}
+                    title={option}
+                    onPress={() => {
+                      setCategory(option);
+                      setMenuVisible(false);
+                    }}
+                    titleStyle={{ color: colors.text }}
+                    accessibilityLabel={`Select ${option}`}
+                  />
+                ))}
+              </Menu>
+            </View>
+
+            <SegmentedButtons
+              value={type}
+              onValueChange={setType}
+              buttons={[
+                {
+                  value: 'income',
+                  label: 'Income',
+                  accessibilityLabel: 'Income transaction',
+                },
+                {
+                  value: 'expense',
+                  label: 'Expense',
+                  accessibilityLabel: 'Expense transaction',
+                },
+              ]}
+              density="regular"
+              style={{ marginBottom: spacing(1.5) }}
+              theme={{ colors: { secondaryContainer: colors.segmentBackground, onSecondaryContainer: colors.text } }}
+            />
+
+            {!!error && (
+              <HelperText type="error" visible accessibilityRole="alert">
+                {error}
+              </HelperText>
+            )}
+
+            <HLButton
+              title={submitting ? 'Saving…' : 'Save transaction'}
+              onPress={handleSubmit}
+              disabled={submitting}
+              accessibilityLabel="Save transaction"
+            />
+          </GlassCard>
+        </ScrollView>
+      </SafeAreaView>
+    </KeyboardAvoidingView>
+  );
+}

--- a/app/screens/Dashboard.js
+++ b/app/screens/Dashboard.js
@@ -1,3 +1,4 @@
+import { useMemo } from 'react';
 import { View, ScrollView } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { LinearGradient } from 'expo-linear-gradient';
@@ -5,19 +6,43 @@ import { Text, Chip } from 'react-native-paper';
 import GlassCard from '../components/GlassCard';
 import HLButton from '../components/HLButton';
 import ProgressRing from '../components/ProgressRing';
-import Row from '../components/Row';
 import AIChat from '../components/AIChat';
-import AnimatedNumber from '../components/AnimatedNumber';  // 👈 add this
+import AnimatedNumber from '../components/AnimatedNumber';
+import TransactionList from '../components/TransactionList';
+import { useTransactions } from '../lib/transactions';
 import { useColors, spacing, radii } from '../lib/theme';
 
 export default function Dashboard({ navigation }) {
   const colors = useColors();
+  const { transactions, loading, deleteTransaction } = useTransactions();
 
-  // Example values (we'll replace with real data later)
-  const savingsGoal = 800;
-  const saved = 520;
-  const progress = saved / savingsGoal;
-  const balance = 1650; // 👈 this will animate
+  const { incomeTotal, expenseTotal, netBalance, savingsGoal, savedAmount, progress } = useMemo(() => {
+    const aggregates = transactions.reduce(
+      (acc, transaction) => {
+        if (transaction.type === 'income') {
+          acc.income += transaction.amount;
+        } else {
+          acc.expense += transaction.amount;
+        }
+        return acc;
+      },
+      { income: 0, expense: 0 },
+    );
+
+    const net = aggregates.income - aggregates.expense;
+    const goal = Math.max(aggregates.income * 0.5, 500);
+    const saved = Math.max(net, 0);
+    const pct = goal > 0 ? Math.min(saved / goal, 1) : 0;
+
+    return {
+      incomeTotal: aggregates.income,
+      expenseTotal: aggregates.expense,
+      netBalance: net,
+      savingsGoal: goal,
+      savedAmount: saved,
+      progress: pct,
+    };
+  }, [transactions]);
 
   return (
     <SafeAreaView style={{ flex: 1 }}>
@@ -30,7 +55,7 @@ export default function Dashboard({ navigation }) {
             mode="outlined"
             style={{
               alignSelf: 'flex-start',
-              backgroundColor: 'rgba(82, 255, 197, 0.12)',
+              backgroundColor: colors.accent3 + '21',
               borderColor: colors.accent3,
               borderRadius: radii.lg,
             }}
@@ -46,76 +71,106 @@ export default function Dashboard({ navigation }) {
           </Text>
         </View>
 
-        {/* Top summary with animated balance */}
-        <GlassCard style={{ marginBottom: spacing(2) }} accessibilityLabel="Current balance summary">
+        <GlassCard style={{ marginBottom: spacing(2) }} accessibilityLabel="Cashflow summary">
           <LinearGradient
-            colors={[colors.accent1 + '26', colors.accent2 + '26']}
+            colors={[colors.accent1 + '2E', colors.accent2 + '2E']}
             start={{ x: 0, y: 0 }}
             end={{ x: 1, y: 1 }}
-            style={{ borderRadius: radii.lg, padding: spacing(2), flexDirection: 'row', gap: spacing(2) }}
+            style={{
+              borderRadius: radii.lg,
+              padding: spacing(2),
+            }}
           >
-            <View style={{ justifyContent: 'center' }}>
-              <ProgressRing size={120} stroke={12} progress={progress} />
-              <Text style={{ color: colors.subtext, textAlign: 'center', marginTop: spacing(1) }}>65% toward goal</Text>
-            </View>
-            <View style={{ flex: 1, justifyContent: 'center' }}>
-              <Text style={{ color: colors.subtext, marginBottom: 4 }}>Command balance</Text>
-              <AnimatedNumber
-                value={balance}
-                style={{ color: colors.text, fontSize: 34, fontWeight: '800' }}
-              />
-              <Text style={{ color: colors.success, marginTop: spacing(1), fontWeight: '600' }}>+${saved} toward savings
-              </Text>
-              <Text style={{ color: colors.subtext, marginTop: spacing(1), lineHeight: 18 }}>
-                Projected runway: 34 days · Next autopilot transfer hits tomorrow morning.
-              </Text>
-              <HLButton
-                title="Link another bank"
-                style={{ marginTop: spacing(2) }}
-                onPress={() => navigation.navigate('LinkBank')}
-                accessibilityLabel="Link a bank account"
-              />
+            <View style={{ flexDirection: 'row', gap: spacing(2) }}>
+              <View style={{ alignItems: 'center', justifyContent: 'center' }}>
+                <ProgressRing size={120} stroke={12} progress={progress} />
+                <Text style={{ color: colors.subtext, textAlign: 'center', marginTop: spacing(1) }}>
+                  {Math.round(progress * 100)}% toward goal (${savingsGoal.toFixed(0)})
+                </Text>
+              </View>
+              <View style={{ flex: 1, justifyContent: 'center' }}>
+                <Text style={{ color: colors.subtext, marginBottom: spacing(1) }}>Command balance</Text>
+                <AnimatedNumber
+                  value={netBalance}
+                  precision={2}
+                  style={{ color: colors.text, fontSize: 34, fontWeight: '800' }}
+                />
+                <View
+                  style={{
+                    flexDirection: 'row',
+                    marginTop: spacing(2),
+                    justifyContent: 'space-between',
+                    gap: spacing(1),
+                  }}
+                >
+                  <View style={{ flex: 1 }}>
+                    <Text style={{ color: colors.subtext, marginBottom: 4 }}>Income</Text>
+                    <AnimatedNumber
+                      value={incomeTotal}
+                      precision={2}
+                      style={{ color: colors.success, fontSize: 20, fontWeight: '700' }}
+                    />
+                  </View>
+                  <View style={{ flex: 1 }}>
+                    <Text style={{ color: colors.subtext, marginBottom: 4 }}>Expenses</Text>
+                    <AnimatedNumber
+                      value={expenseTotal}
+                      precision={2}
+                      style={{ color: colors.danger, fontSize: 20, fontWeight: '700' }}
+                    />
+                  </View>
+                </View>
+                <Text style={{ color: colors.subtext, marginTop: spacing(1), lineHeight: 18 }}>
+                  {savedAmount > 0
+                    ? `Projected runway: ${Math.max(Math.round(savedAmount / 50), 1)} days · Keep the flywheel turning.`
+                    : 'Log a few income hits to kickstart your runway insights.'}
+                </Text>
+                <HLButton
+                  title="Add transaction"
+                  style={{ marginTop: spacing(2) }}
+                  onPress={() => navigation.navigate('AddTransaction')}
+                  accessibilityLabel="Add a new transaction"
+                />
+              </View>
             </View>
           </LinearGradient>
         </GlassCard>
 
-        <View style={{ flexDirection: 'row', gap: spacing(2), marginBottom: spacing(2) }}>
-          <GlassCard
-            style={{ flex: 1 }}
-            accessibilityLabel="Savings automation status"
-          >
-            <Text style={{ color: colors.subtext, fontWeight: '600' }}>Automation</Text>
-            <Text style={{ color: colors.text, fontSize: 26, fontWeight: '800', marginTop: spacing(0.5) }}>
-              4 active rituals
-            </Text>
-            <Text style={{ color: colors.subtext, marginTop: spacing(1), lineHeight: 18 }}>
-              AI allocates $180/week across rainy day, tax vault, and gear upgrades.
-            </Text>
-          </GlassCard>
-
-          <GlassCard
-            style={{ flex: 1 }}
-            accessibilityLabel="Credit health insights"
-          >
-            <Text style={{ color: colors.subtext, fontWeight: '600' }}>Credit pulse</Text>
-            <Text style={{ color: colors.text, fontSize: 26, fontWeight: '800', marginTop: spacing(0.5) }}>
-              782 · Stable
-            </Text>
-            <Text style={{ color: colors.success, marginTop: spacing(1), fontWeight: '600' }}>
-              +12 pts this month
-            </Text>
-            <Text style={{ color: colors.subtext, marginTop: spacing(1), lineHeight: 18 }}>
-              Utilization trimmed to 18% after AI auto-pay.
-            </Text>
-          </GlassCard>
-        </View>
-
-        <GlassCard style={{ marginBottom: spacing(2) }} accessibilityLabel="Recent activity">
-          <Text style={{ color: colors.text, fontWeight: '700', marginBottom: spacing(1) }}>Recent activity</Text>
-          <Row title="Uber Eats" subtitle="Dining" amount="24.90" negative />
-          <Row title="Deposit: DoorDash" subtitle="Side Hustle" amount="118.00" />
-          <Row title="Shell Gas" subtitle="Auto" amount="42.30" negative />
+        <GlassCard
+          style={{ marginBottom: spacing(2) }}
+          accessibilityLabel="Automation status"
+        >
+          <Text style={{ color: colors.subtext, fontWeight: '600' }}>Automation</Text>
+          <Text style={{ color: colors.text, fontSize: 26, fontWeight: '800', marginTop: spacing(0.5) }}>
+            Rituals humming
+          </Text>
+          <Text style={{ color: colors.subtext, marginTop: spacing(1), lineHeight: 18 }}>
+            AI allocates surplus income across rainy day, tax vault, and reinvestment envelopes.
+          </Text>
         </GlassCard>
+
+        <GlassCard
+          style={{ marginBottom: spacing(2) }}
+          accessibilityLabel="Credit health insights"
+        >
+          <Text style={{ color: colors.subtext, fontWeight: '600' }}>Credit pulse</Text>
+          <Text style={{ color: colors.text, fontSize: 26, fontWeight: '800', marginTop: spacing(0.5) }}>
+            782 · Stable
+          </Text>
+          <Text style={{ color: colors.success, marginTop: spacing(1), fontWeight: '600' }}>
+            +12 pts this month
+          </Text>
+          <Text style={{ color: colors.subtext, marginTop: spacing(1), lineHeight: 18 }}>
+            Utilization trimmed to 18% after AI auto-pay.
+          </Text>
+        </GlassCard>
+
+        <TransactionList
+          transactions={transactions}
+          loading={loading}
+          onDelete={deleteTransaction}
+          style={{ marginBottom: spacing(2) }}
+        />
 
         <AIChat />
       </ScrollView>

--- a/app/screens/SignIn.js
+++ b/app/screens/SignIn.js
@@ -30,11 +30,7 @@ export default function SignIn({ navigation }) {
       await signInWithEmailAndPassword(auth, email.trim(), pw);
       navigation.replace('AppLock');
     } catch (error) {
-<<<<<<< HEAD
-      setErr(error.message || 'Sign in failed');
-=======
       setErr(error?.message || 'Sign in failed');
->>>>>>> 53fbc4eaf50aa56101b353f9eb128c405a27dff9
     } finally {
       setLoading(false);
     }

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -35,7 +35,9 @@ export default [
         console: 'readonly',
         fetch: 'readonly',
         requestAnimationFrame: 'readonly',
-        require: 'readonly'
+        require: 'readonly',
+        setTimeout: 'readonly',
+        clearTimeout: 'readonly'
       }
     },
     plugins: {
@@ -58,6 +60,37 @@ export default [
       'react-native/no-unused-styles': 'error',
       'react-native/no-inline-styles': 'off'
     }
+  },
+  {
+    files: ['__tests__/**/*.js', '**/*.test.{js,jsx,ts,tsx}'],
+    languageOptions: {
+      globals: {
+        describe: 'readonly',
+        it: 'readonly',
+        test: 'readonly',
+        expect: 'readonly',
+        beforeAll: 'readonly',
+        afterAll: 'readonly',
+        beforeEach: 'readonly',
+        afterEach: 'readonly',
+        jest: 'readonly'
+      }
+    }
+  },
+  {
+    files: ['.eslintrc.js', 'scripts/**/*.js', 'vendor/**/*.js'],
+    languageOptions: {
+      sourceType: 'script',
+      globals: {
+        module: 'writable',
+        require: 'readonly',
+        process: 'readonly',
+        __dirname: 'readonly',
+        global: 'readonly',
+        console: 'readonly'
+      }
+    }
+
   },
   {
     files: ['babel.config.js'],

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "hustle-ledger",
       "version": "1.0.0",
       "dependencies": {
+        "@react-native-async-storage/async-storage": "^1.23.1",
         "@react-navigation/bottom-tabs": "^7.4.7",
         "@react-navigation/native": "^7.1.17",
         "@react-navigation/native-stack": "^7.3.26",
@@ -29,8 +30,6 @@
         "react-native-vector-icons": "^10.3.0",
         "react-native-worklets": "0.5.1",
         "react-native-worklets-core": "1.5.0"
-<<<<<<< HEAD
-=======
       },
       "devDependencies": {
         "@eslint/js": "^9.18.0",
@@ -40,7 +39,6 @@
         "eslint-plugin-react-hooks": "^5.2.0",
         "eslint-plugin-react-native": "^5.0.0",
         "rimraf": "^5.0.0"
->>>>>>> 53fbc4eaf50aa56101b353f9eb128c405a27dff9
       }
     },
     "node_modules/@0no-co/graphql.web": {
@@ -206,6 +204,26 @@
       },
       "peerDependencies": {
         "@babel/core": "^7.4.0 || ^8.0.0-0 <8.0.0"
+      }
+    },
+    "node_modules/@babel/helper-define-polyfill-provider/node_modules/resolve": {
+      "version": "1.22.10",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.10.tgz",
+      "integrity": "sha512-NPRy+/ncIMeDlTAsuqwKIiferiawhefFJtkNSW0qZJEqMEb+qBt/77B/jGeeek+F0uOeN05CDa6HXbbIgtVX4w==",
+      "license": "MIT",
+      "dependencies": {
+        "is-core-module": "^2.16.0",
+        "path-parse": "^1.0.7",
+        "supports-preserve-symlinks-flag": "^1.0.0"
+      },
+      "bin": {
+        "resolve": "bin/resolve"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/@babel/helper-globals": {
@@ -1568,8 +1586,6 @@
         "node": ">=0.8.0"
       }
     },
-<<<<<<< HEAD
-=======
     "node_modules/@eslint-community/eslint-utils": {
       "version": "4.9.0",
       "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.9.0.tgz",
@@ -1627,30 +1643,6 @@
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
     },
-    "node_modules/@eslint/config-array/node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0",
-        "concat-map": "0.0.1"
-      }
-    },
-    "node_modules/@eslint/config-array/node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^1.1.7"
-      },
-      "engines": {
-        "node": "*"
-      }
-    },
     "node_modules/@eslint/config-helpers": {
       "version": "0.3.1",
       "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.3.1.tgz",
@@ -1698,70 +1690,6 @@
         "url": "https://opencollective.com/eslint"
       }
     },
-    "node_modules/@eslint/eslintrc/node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0",
-        "concat-map": "0.0.1"
-      }
-    },
-    "node_modules/@eslint/eslintrc/node_modules/import-fresh": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
-      "integrity": "sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "parent-module": "^1.0.0",
-        "resolve-from": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@eslint/eslintrc/node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^1.1.7"
-      },
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/@eslint/eslintrc/node_modules/resolve-from": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
-      "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/@eslint/eslintrc/node_modules/strip-json-comments": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
-      "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/@eslint/js": {
       "version": "9.36.0",
       "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.36.0.tgz",
@@ -1799,107 +1727,6 @@
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
     },
-    "node_modules/@expo/cli": {
-      "version": "54.0.8",
-      "resolved": "https://registry.npmjs.org/@expo/cli/-/cli-54.0.8.tgz",
-      "integrity": "sha512-bRJXvtjgxpyElmJuKLotWyIW5j9a2K3rGUjd2A8LRcFimrZp0wwuKPQjlUK0sFNbU7zHWfxubNq/B+UkUNkCxw==",
-      "license": "MIT",
-      "dependencies": {
-        "@0no-co/graphql.web": "^1.0.8",
-        "@expo/code-signing-certificates": "^0.0.5",
-        "@expo/config": "~12.0.9",
-        "@expo/config-plugins": "~54.0.1",
-        "@expo/devcert": "^1.1.2",
-        "@expo/env": "~2.0.7",
-        "@expo/image-utils": "^0.8.7",
-        "@expo/json-file": "^10.0.7",
-        "@expo/mcp-tunnel": "~0.0.7",
-        "@expo/metro": "~54.0.0",
-        "@expo/metro-config": "~54.0.5",
-        "@expo/osascript": "^2.3.7",
-        "@expo/package-manager": "^1.9.8",
-        "@expo/plist": "^0.4.7",
-        "@expo/prebuild-config": "^54.0.3",
-        "@expo/schema-utils": "^0.1.7",
-        "@expo/server": "^0.7.5",
-        "@expo/spawn-async": "^1.7.2",
-        "@expo/ws-tunnel": "^1.0.1",
-        "@expo/xcpretty": "^4.3.0",
-        "@react-native/dev-middleware": "0.81.4",
-        "@urql/core": "^5.0.6",
-        "@urql/exchange-retry": "^1.3.0",
-        "accepts": "^1.3.8",
-        "arg": "^5.0.2",
-        "better-opn": "~3.0.2",
-        "bplist-creator": "0.1.0",
-        "bplist-parser": "^0.3.1",
-        "chalk": "^4.0.0",
-        "ci-info": "^3.3.0",
-        "compression": "^1.7.4",
-        "connect": "^3.7.0",
-        "debug": "^4.3.4",
-        "env-editor": "^0.4.1",
-        "freeport-async": "^2.0.0",
-        "getenv": "^2.0.0",
-        "glob": "^10.4.2",
-        "lan-network": "^0.1.6",
-        "minimatch": "^9.0.0",
-        "node-forge": "^1.3.1",
-        "npm-package-arg": "^11.0.0",
-        "ora": "^3.4.0",
-        "picomatch": "^3.0.1",
-        "pretty-bytes": "^5.6.0",
-        "pretty-format": "^29.7.0",
-        "progress": "^2.0.3",
-        "prompts": "^2.3.2",
-        "qrcode-terminal": "0.11.0",
-        "require-from-string": "^2.0.2",
-        "requireg": "^0.2.2",
-        "resolve": "^1.22.2",
-        "resolve-from": "^5.0.0",
-        "resolve.exports": "^2.0.3",
-        "semver": "^7.6.0",
-        "send": "^0.19.0",
-        "slugify": "^1.3.4",
-        "source-map-support": "~0.5.21",
-        "stacktrace-parser": "^0.1.10",
-        "structured-headers": "^0.4.1",
-        "tar": "^7.4.3",
-        "terminal-link": "^2.1.1",
-        "undici": "^6.18.2",
-        "wrap-ansi": "^7.0.0",
-        "ws": "^8.12.1"
-      },
-      "bin": {
-        "expo-internal": "build/bin/cli"
-      },
-      "peerDependencies": {
-        "expo": "*",
-        "expo-router": "*",
-        "react-native": "*"
-      },
-      "peerDependenciesMeta": {
-        "expo-router": {
-          "optional": true
-        },
-        "react-native": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@expo/cli/node_modules/semver": {
-      "version": "7.7.2",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
-      "integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
->>>>>>> 53fbc4eaf50aa56101b353f9eb128c405a27dff9
     "node_modules/@expo/code-signing-certificates": {
       "version": "0.0.5",
       "resolved": "https://registry.npmjs.org/@expo/code-signing-certificates/-/code-signing-certificates-0.0.5.tgz",
@@ -2068,6 +1895,30 @@
         "fingerprint": "bin/cli.js"
       }
     },
+    "node_modules/@expo/fingerprint/node_modules/brace-expansion": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
+      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/@expo/fingerprint/node_modules/minimatch": {
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
+      "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/@expo/fingerprint/node_modules/semver": {
       "version": "7.7.2",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
@@ -2226,6 +2077,30 @@
         }
       }
     },
+    "node_modules/@expo/metro-config/node_modules/brace-expansion": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
+      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/@expo/metro-config/node_modules/minimatch": {
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
+      "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/@expo/osascript": {
       "version": "2.3.7",
       "resolved": "https://registry.npmjs.org/@expo/osascript/-/osascript-2.3.7.tgz",
@@ -2379,70 +2254,6 @@
       "license": "MIT",
       "dependencies": {
         "@babel/highlight": "^7.10.4"
-      }
-    },
-    "node_modules/@expo/xcpretty/node_modules/argparse": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
-      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-      "license": "Python-2.0"
-    },
-    "node_modules/@expo/xcpretty/node_modules/find-up": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
-      "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
-      "license": "MIT",
-      "dependencies": {
-        "locate-path": "^6.0.0",
-        "path-exists": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@expo/xcpretty/node_modules/js-yaml": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
-      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
-      "license": "MIT",
-      "dependencies": {
-        "argparse": "^2.0.1"
-      },
-      "bin": {
-        "js-yaml": "bin/js-yaml.js"
-      }
-    },
-    "node_modules/@expo/xcpretty/node_modules/locate-path": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
-      "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
-      "license": "MIT",
-      "dependencies": {
-        "p-locate": "^5.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@expo/xcpretty/node_modules/p-locate": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
-      "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
-      "license": "MIT",
-      "dependencies": {
-        "p-limit": "^3.0.2"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/@firebase/ai": {
@@ -3190,6 +3001,15 @@
         "node": ">=8"
       }
     },
+    "node_modules/@istanbuljs/load-nyc-config/node_modules/argparse": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "license": "MIT",
+      "dependencies": {
+        "sprintf-js": "~1.0.2"
+      }
+    },
     "node_modules/@istanbuljs/load-nyc-config/node_modules/camelcase": {
       "version": "5.3.1",
       "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
@@ -3197,6 +3017,71 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/@istanbuljs/load-nyc-config/node_modules/find-up": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+      "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+      "license": "MIT",
+      "dependencies": {
+        "locate-path": "^5.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@istanbuljs/load-nyc-config/node_modules/js-yaml": {
+      "version": "3.14.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
+      "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^1.0.7",
+        "esprima": "^4.0.0"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/@istanbuljs/load-nyc-config/node_modules/locate-path": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+      "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+      "license": "MIT",
+      "dependencies": {
+        "p-locate": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@istanbuljs/load-nyc-config/node_modules/p-limit": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+      "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+      "license": "MIT",
+      "dependencies": {
+        "p-try": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@istanbuljs/load-nyc-config/node_modules/p-locate": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+      "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+      "license": "MIT",
+      "dependencies": {
+        "p-limit": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/@istanbuljs/schema": {
@@ -3436,6 +3321,18 @@
       "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==",
       "license": "BSD-3-Clause"
     },
+    "node_modules/@react-native-async-storage/async-storage": {
+      "version": "1.24.0",
+      "resolved": "https://registry.npmjs.org/@react-native-async-storage/async-storage/-/async-storage-1.24.0.tgz",
+      "integrity": "sha512-W4/vbwUOYOjco0x3toB8QCr7EjIP6nE9G7o8PMguvvjYT5Awg09lyV4enACRx4s++PPulBiBSjL0KTFx2u0Z/g==",
+      "license": "MIT",
+      "dependencies": {
+        "merge-options": "^3.0.4"
+      },
+      "peerDependencies": {
+        "react-native": "^0.0.0-0 || >=0.60 <1.0"
+      }
+    },
     "node_modules/@react-native/assets-registry": {
       "version": "0.81.4",
       "resolved": "https://registry.npmjs.org/@react-native/assets-registry/-/assets-registry-0.81.4.tgz",
@@ -3538,16 +3435,6 @@
         "@babel/core": "*"
       }
     },
-    "node_modules/@react-native/codegen/node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0",
-        "concat-map": "0.0.1"
-      }
-    },
     "node_modules/@react-native/codegen/node_modules/glob": {
       "version": "7.2.3",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
@@ -3567,18 +3454,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/@react-native/codegen/node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^1.1.7"
-      },
-      "engines": {
-        "node": "*"
       }
     },
     "node_modules/@react-native/community-cli-plugin": {
@@ -4153,13 +4028,10 @@
       "license": "MIT"
     },
     "node_modules/argparse": {
-      "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
-      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
-      "license": "MIT",
-      "dependencies": {
-        "sprintf-js": "~1.0.2"
-      }
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "license": "Python-2.0"
     },
     "node_modules/array-buffer-byte-length": {
       "version": "1.0.2",
@@ -4573,9 +4445,9 @@
       "license": "MIT"
     },
     "node_modules/baseline-browser-mapping": {
-      "version": "2.8.6",
-      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.8.6.tgz",
-      "integrity": "sha512-wrH5NNqren/QMtKUEEJf7z86YjfqW/2uw3IL3/xpqZUC95SSVIFXYQeeGjL6FT/X68IROu6RMehZQS5foy2BXw==",
+      "version": "2.8.7",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.8.7.tgz",
+      "integrity": "sha512-bxxN2M3a4d1CRoQC//IqsR5XrLh0IJ8TCv2x6Y9N0nckNz/rTjZB3//GGscZziZOxmjP55rzxg/ze7usFI9FqQ==",
       "license": "Apache-2.0",
       "bin": {
         "baseline-browser-mapping": "dist/cli.js"
@@ -4647,12 +4519,13 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
       "license": "MIT",
       "dependencies": {
-        "balanced-match": "^1.0.0"
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
       }
     },
     "node_modules/braces": {
@@ -4810,6 +4683,15 @@
         "node": ">=4"
       }
     },
+    "node_modules/caller-callsite/node_modules/callsites": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/callsites/-/callsites-2.0.0.tgz",
+      "integrity": "sha512-ksWePWBloaWPxJYQ8TL0JHvtci6G5QTKwQ95RcWAa/lzoAKuAOflGdAK92hpHXjkwb8zLxoLNUoNYZgVsaJzvQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/caller-path": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/caller-path/-/caller-path-2.0.0.tgz",
@@ -4823,12 +4705,13 @@
       }
     },
     "node_modules/callsites": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/callsites/-/callsites-2.0.0.tgz",
-      "integrity": "sha512-ksWePWBloaWPxJYQ8TL0JHvtci6G5QTKwQ95RcWAa/lzoAKuAOflGdAK92hpHXjkwb8zLxoLNUoNYZgVsaJzvQ==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
+      "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
+      "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">=4"
+        "node": ">=6"
       }
     },
     "node_modules/camelcase": {
@@ -4918,6 +4801,43 @@
         "lighthouse-logger": "^1.0.0",
         "mkdirp": "^1.0.4",
         "rimraf": "^3.0.2"
+      }
+    },
+    "node_modules/chromium-edge-launcher/node_modules/glob": {
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+      "deprecated": "Glob versions prior to v9 are no longer supported",
+      "license": "ISC",
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.1.1",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/chromium-edge-launcher/node_modules/rimraf": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+      "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+      "deprecated": "Rimraf versions prior to v4 are no longer supported",
+      "license": "ISC",
+      "dependencies": {
+        "glob": "^7.1.3"
+      },
+      "bin": {
+        "rimraf": "bin.js"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/ci-info": {
@@ -5196,8 +5116,6 @@
         "node": ">=4"
       }
     },
-<<<<<<< HEAD
-=======
     "node_modules/cosmiconfig/node_modules/argparse": {
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
@@ -5205,6 +5123,19 @@
       "license": "MIT",
       "dependencies": {
         "sprintf-js": "~1.0.2"
+      }
+    },
+    "node_modules/cosmiconfig/node_modules/import-fresh": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-2.0.0.tgz",
+      "integrity": "sha512-eZ5H8rcgYazHbKC3PG4ClHNykCSxtAhxSSEM+2mb+7evD2CKF5V7c0dNum7AdpDh0ZdICwZY9sRSn8f+KH96sg==",
+      "license": "MIT",
+      "dependencies": {
+        "caller-path": "^2.0.0",
+        "resolve-from": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/cosmiconfig/node_modules/js-yaml": {
@@ -5218,6 +5149,15 @@
       },
       "bin": {
         "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/cosmiconfig/node_modules/resolve-from": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-3.0.0.tgz",
+      "integrity": "sha512-GnlH6vxLymXJNMBo7XP1fJIzBFbdYt49CuTwmB/6N53t+kMPRMFKz783LlQ4tv28XoQfMWinAJX6WCGf2IlaIw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/cross-env": {
@@ -5239,7 +5179,6 @@
         "yarn": ">=1"
       }
     },
->>>>>>> 53fbc4eaf50aa56101b353f9eb128c405a27dff9
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
@@ -6016,48 +5955,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/eslint-plugin-react/node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0",
-        "concat-map": "0.0.1"
-      }
-    },
-    "node_modules/eslint-plugin-react/node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^1.1.7"
-      },
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/eslint-plugin-react/node_modules/resolve": {
-      "version": "2.0.0-next.5",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-2.0.0-next.5.tgz",
-      "integrity": "sha512-U7WjGVG9sH8tvjW5SmGbQuui75FiyjAX72HX15DwBBwF9dNiQZRQAg9nnPhYy+TUnE0+VcrttuvNI8oSxZcocA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "is-core-module": "^2.13.0",
-        "path-parse": "^1.0.7",
-        "supports-preserve-symlinks-flag": "^1.0.0"
-      },
-      "bin": {
-        "resolve": "bin/resolve"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/eslint-scope": {
       "version": "8.4.0",
       "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-8.4.0.tgz",
@@ -6086,30 +5983,6 @@
       },
       "funding": {
         "url": "https://opencollective.com/eslint"
-      }
-    },
-    "node_modules/eslint/node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0",
-        "concat-map": "0.0.1"
-      }
-    },
-    "node_modules/eslint/node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^1.1.7"
-      },
-      "engines": {
-        "node": "*"
       }
     },
     "node_modules/espree": {
@@ -6489,6 +6362,15 @@
         }
       }
     },
+    "node_modules/expo/node_modules/brace-expansion": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
+      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
     "node_modules/expo/node_modules/ci-info": {
       "version": "3.9.0",
       "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.9.0.tgz",
@@ -6510,6 +6392,21 @@
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
       "license": "MIT"
     },
+    "node_modules/expo/node_modules/minimatch": {
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
+      "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/expo/node_modules/picomatch": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-3.0.1.tgz",
@@ -6520,6 +6417,26 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/expo/node_modules/resolve": {
+      "version": "1.22.10",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.10.tgz",
+      "integrity": "sha512-NPRy+/ncIMeDlTAsuqwKIiferiawhefFJtkNSW0qZJEqMEb+qBt/77B/jGeeek+F0uOeN05CDa6HXbbIgtVX4w==",
+      "license": "MIT",
+      "dependencies": {
+        "is-core-module": "^2.16.0",
+        "path-parse": "^1.0.7",
+        "supports-preserve-symlinks-flag": "^1.0.0"
+      },
+      "bin": {
+        "resolve": "bin/resolve"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/expo/node_modules/semver": {
@@ -6712,16 +6629,19 @@
       "license": "MIT"
     },
     "node_modules/find-up": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
-      "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+      "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
       "license": "MIT",
       "dependencies": {
-        "locate-path": "^5.0.0",
+        "locate-path": "^6.0.0",
         "path-exists": "^4.0.0"
       },
       "engines": {
-        "node": ">=8"
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/firebase": {
@@ -7029,6 +6949,30 @@
         "node": ">=10.13.0"
       }
     },
+    "node_modules/glob/node_modules/brace-expansion": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
+      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/glob/node_modules/minimatch": {
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
+      "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/global-dirs": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/global-dirs/-/global-dirs-0.1.1.tgz",
@@ -7325,22 +7269,27 @@
       }
     },
     "node_modules/import-fresh": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-2.0.0.tgz",
-      "integrity": "sha512-eZ5H8rcgYazHbKC3PG4ClHNykCSxtAhxSSEM+2mb+7evD2CKF5V7c0dNum7AdpDh0ZdICwZY9sRSn8f+KH96sg==",
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
+      "integrity": "sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
-        "caller-path": "^2.0.0",
-        "resolve-from": "^3.0.0"
+        "parent-module": "^1.0.0",
+        "resolve-from": "^4.0.0"
       },
       "engines": {
-        "node": ">=4"
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/import-fresh/node_modules/resolve-from": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-3.0.0.tgz",
-      "integrity": "sha512-GnlH6vxLymXJNMBo7XP1fJIzBFbdYt49CuTwmB/6N53t+kMPRMFKz783LlQ4tv28XoQfMWinAJX6WCGf2IlaIw==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+      "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=4"
@@ -7683,6 +7632,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-plain-obj": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-2.1.0.tgz",
+      "integrity": "sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/is-regex": {
@@ -8099,13 +8057,12 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "3.14.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
-      "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
+      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
       "license": "MIT",
       "dependencies": {
-        "argparse": "^1.0.7",
-        "esprima": "^4.0.0"
+        "argparse": "^2.0.1"
       },
       "bin": {
         "js-yaml": "bin/js-yaml.js"
@@ -8495,15 +8452,18 @@
       "license": "MIT"
     },
     "node_modules/locate-path": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
-      "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+      "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
       "license": "MIT",
       "dependencies": {
-        "p-locate": "^4.1.0"
+        "p-locate": "^5.0.0"
       },
       "engines": {
-        "node": ">=8"
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/lodash.camelcase": {
@@ -8677,6 +8637,18 @@
       "resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-5.2.1.tgz",
       "integrity": "sha512-zYiwtZUcYyXKo/np96AGZAckk+FWWsUdJ3cHGGmld7+AhvcWmQyGCYUh1hc4Q/pkOhb65dQR/pqCyK0cOaHz4Q==",
       "license": "MIT"
+    },
+    "node_modules/merge-options": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/merge-options/-/merge-options-3.0.4.tgz",
+      "integrity": "sha512-2Sug1+knBjkaMsMgf1ctR1Ujx+Ayku4EdJN4Z+C2+JzoeF7A3OZ9KM2GY0CpQS51NR61LTurMJrRKPhSs3ZRTQ==",
+      "license": "MIT",
+      "dependencies": {
+        "is-plain-obj": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/merge-stream": {
       "version": "2.0.0",
@@ -9009,18 +8981,15 @@
       }
     },
     "node_modules/minimatch": {
-      "version": "9.0.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
-      "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
       "license": "ISC",
       "dependencies": {
-        "brace-expansion": "^2.0.1"
+        "brace-expansion": "^1.1.7"
       },
       "engines": {
-        "node": ">=16 || 14 >=14.17"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
+        "node": "*"
       }
     },
     "node_modules/minimist": {
@@ -9535,27 +9504,15 @@
       }
     },
     "node_modules/p-locate": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
-      "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+      "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
       "license": "MIT",
       "dependencies": {
-        "p-limit": "^2.2.0"
+        "p-limit": "^3.0.2"
       },
       "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/p-locate/node_modules/p-limit": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
-      "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
-      "license": "MIT",
-      "dependencies": {
-        "p-try": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=6"
+        "node": ">=10"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -9585,16 +9542,6 @@
       "dependencies": {
         "callsites": "^3.0.0"
       },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/parent-module/node_modules/callsites": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
-      "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
-      "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=6"
       }
@@ -9977,6 +9924,15 @@
       },
       "bin": {
         "rc": "cli.js"
+      }
+    },
+    "node_modules/rc/node_modules/strip-json-comments": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+      "integrity": "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/react": {
@@ -10376,16 +10332,6 @@
         "node": ">=10"
       }
     },
-    "node_modules/react-native/node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0",
-        "concat-map": "0.0.1"
-      }
-    },
     "node_modules/react-native/node_modules/commander": {
       "version": "12.1.0",
       "resolved": "https://registry.npmjs.org/commander/-/commander-12.1.0.tgz",
@@ -10414,18 +10360,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/react-native/node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^1.1.7"
-      },
-      "engines": {
-        "node": "*"
       }
     },
     "node_modules/react-native/node_modules/semver": {
@@ -10602,20 +10536,18 @@
       }
     },
     "node_modules/resolve": {
-      "version": "1.22.10",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.10.tgz",
-      "integrity": "sha512-NPRy+/ncIMeDlTAsuqwKIiferiawhefFJtkNSW0qZJEqMEb+qBt/77B/jGeeek+F0uOeN05CDa6HXbbIgtVX4w==",
+      "version": "2.0.0-next.5",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-2.0.0-next.5.tgz",
+      "integrity": "sha512-U7WjGVG9sH8tvjW5SmGbQuui75FiyjAX72HX15DwBBwF9dNiQZRQAg9nnPhYy+TUnE0+VcrttuvNI8oSxZcocA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
-        "is-core-module": "^2.16.0",
+        "is-core-module": "^2.13.0",
         "path-parse": "^1.0.7",
         "supports-preserve-symlinks-flag": "^1.0.0"
       },
       "bin": {
         "resolve": "bin/resolve"
-      },
-      "engines": {
-        "node": ">= 0.4"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -10677,64 +10609,21 @@
       "license": "ISC"
     },
     "node_modules/rimraf": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
-      "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
-      "deprecated": "Rimraf versions prior to v4 are no longer supported",
+      "version": "5.0.10",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-5.0.10.tgz",
+      "integrity": "sha512-l0OE8wL34P4nJH/H2ffoaniAokM2qSmrtXHmlpvYr5AVVX8msAyW0l8NVJFDxlSK4u3Uh/f41cQheDVdnYijwQ==",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
-        "glob": "^7.1.3"
+        "glob": "^10.3.7"
       },
       "bin": {
-        "rimraf": "bin.js"
+        "rimraf": "dist/esm/bin.mjs"
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
       }
     },
-<<<<<<< HEAD
-    "node_modules/rimraf/node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0",
-        "concat-map": "0.0.1"
-      }
-    },
-    "node_modules/rimraf/node_modules/glob": {
-      "version": "7.2.3",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
-      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
-      "deprecated": "Glob versions prior to v9 are no longer supported",
-      "license": "ISC",
-      "dependencies": {
-        "fs.realpath": "^1.0.0",
-        "inflight": "^1.0.4",
-        "inherits": "2",
-        "minimatch": "^3.1.1",
-        "once": "^1.3.0",
-        "path-is-absolute": "^1.0.0"
-      },
-      "engines": {
-        "node": "*"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/rimraf/node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^1.1.7"
-      },
-      "engines": {
-        "node": "*"
-=======
     "node_modules/safe-array-concat": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/safe-array-concat/-/safe-array-concat-1.1.3.tgz",
@@ -10753,7 +10642,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
->>>>>>> 53fbc4eaf50aa56101b353f9eb128c405a27dff9
       }
     },
     "node_modules/safe-buffer": {
@@ -10925,62 +10813,6 @@
         "node": ">= 0.8"
       }
     },
-<<<<<<< HEAD
-=======
-    "node_modules/serve-static/node_modules/on-finished": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
-      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
-      "license": "MIT",
-      "dependencies": {
-        "ee-first": "1.1.1"
-      },
-      "engines": {
-        "node": ">= 0.8"
-      }
-    },
-    "node_modules/serve-static/node_modules/send": {
-      "version": "0.19.0",
-      "resolved": "https://registry.npmjs.org/send/-/send-0.19.0.tgz",
-      "integrity": "sha512-dW41u5VfLXu8SJh5bwRmyYUbAoSB3c9uQh6L8h/KtsFREPWpbX1lrljJo186Jc4nmci/sGUZ9a0a0J2zgfq2hw==",
-      "license": "MIT",
-      "dependencies": {
-        "debug": "2.6.9",
-        "depd": "2.0.0",
-        "destroy": "1.2.0",
-        "encodeurl": "~1.0.2",
-        "escape-html": "~1.0.3",
-        "etag": "~1.8.1",
-        "fresh": "0.5.2",
-        "http-errors": "2.0.0",
-        "mime": "1.6.0",
-        "ms": "2.1.3",
-        "on-finished": "2.4.1",
-        "range-parser": "~1.2.1",
-        "statuses": "2.0.1"
-      },
-      "engines": {
-        "node": ">= 0.8.0"
-      }
-    },
-    "node_modules/serve-static/node_modules/send/node_modules/encodeurl": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
-      "integrity": "sha512-TPJXq8JqFaVYm2CWmPvnP2Iyo4ZSM7/QKcSmuMLDObfpH5fi7RUGmd/rTDf+rut/saiDiQEeVTNgAmJEdAOx0w==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.8"
-      }
-    },
-    "node_modules/serve-static/node_modules/statuses": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
-      "integrity": "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.8"
-      }
-    },
     "node_modules/set-function-length": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.2.tgz",
@@ -11030,7 +10862,6 @@
         "node": ">= 0.4"
       }
     },
->>>>>>> 53fbc4eaf50aa56101b353f9eb128c405a27dff9
     "node_modules/setprototypeof": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
@@ -11535,12 +11366,16 @@
       }
     },
     "node_modules/strip-json-comments": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
-      "integrity": "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
+      "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
+      "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">=0.10.0"
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/structured-headers": {
@@ -11705,16 +11540,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/test-exclude/node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0",
-        "concat-map": "0.0.1"
-      }
-    },
     "node_modules/test-exclude/node_modules/glob": {
       "version": "7.2.3",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
@@ -11734,18 +11559,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/test-exclude/node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^1.1.7"
-      },
-      "engines": {
-        "node": "*"
       }
     },
     "node_modules/thenify": {

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
     "@react-navigation/bottom-tabs": "^7.4.7",
     "@react-navigation/native": "^7.1.17",
     "@react-navigation/native-stack": "^7.3.26",
+    "@react-native-async-storage/async-storage": "^1.23.1",
     "expo": "^54.0.10",
     "expo-blur": "~15.0.7",
     "expo-haptics": "~15.0.7",
@@ -26,9 +27,6 @@
   },
   "scripts": {
     "android": "expo run:android",
-<<<<<<< HEAD
-    "ios": "expo run:ios"
-=======
     "ios": "expo run:ios",
     "dev:client": "expo start --dev-client",
     "dev:client:tunnel": "expo start --dev-client --tunnel",
@@ -45,6 +43,5 @@
     "eslint-plugin-react-hooks": "^5.2.0",
     "eslint-plugin-react-native": "^5.0.0",
     "rimraf": "^5.0.0"
->>>>>>> 53fbc4eaf50aa56101b353f9eb128c405a27dff9
   }
 }


### PR DESCRIPTION
## Summary
- wrap the navigation tree in a new AsyncStorage-backed transactions provider and expose an add-transaction route
- implement an Add Transaction screen with validated form controls that persists entries and updates dashboard metrics
- refresh the dashboard with animated income/expense totals and a swipe-to-delete transaction list component plus theme and AppLock polish

## Testing
- npm run lint
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d56294d590832295eaf31afa59590f