### PR TITLE
Pin js-yaml and add maintenance scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
     "react-native-svg": "15.12.1",
     "react-native-vector-icons": "^10.3.0",
     "react-native-worklets": "0.5.1",
-    "react-native-worklets-core": "1.5.0"
+    "react-native-worklets-core": "1.5.0",
+    "js-yaml": "^4.1.0"
   },
   "scripts": {
     "android": "expo run:android",
@@ -33,7 +34,10 @@
     "fix:clean": "rimraf node_modules package-lock.json && npm i",
     "fix:expo-go": "npx expo install react-native-reanimated && npm i react-native-worklets-core@1.5.0 --save-exact",
     "lint": "eslint .",
-    "test": "cross-env node ./testing/run-tests.cjs"
+    "test": "cross-env node ./testing/run-tests.cjs",
+    "clean:deps": "rimraf node_modules package-lock.json || rmdir /s /q node_modules && del package-lock.json",
+    "reinstall": "npm install",
+    "start:clean": "npx expo start -c"
   },
   "devDependencies": {
     "@eslint/js": "^9.18.0",
@@ -42,6 +46,9 @@
     "eslint-plugin-react": "^7.37.2",
     "eslint-plugin-react-hooks": "^5.2.0",
     "eslint-plugin-react-native": "^5.0.0",
-    "rimraf": "^5.0.0"
+    "rimraf": "^5.0.5"
+  },
+  "overrides": {
+    "js-yaml": "4.1.0"
   }
 }


### PR DESCRIPTION
## Summary
- add js-yaml dependency while pinning via overrides
- include cleanup and reinstall helper scripts
- bump rimraf dev dependency to match new cleanup script requirements

## Testing
- npm run lint *(fails: existing merge conflict markers in ESLint configuration)*
- npm test *(fails: existing merge conflict markers in tests and theme module)*

------
https://chatgpt.com/codex/tasks/task_e_68d88a1a31388322a7239ec0f959272f