### PR TITLE
feat: restore auth screens and stabilize lint/tests

### DIFF
--- a/App.js
+++ b/App.js
@@ -12,16 +12,6 @@ import {
 import { NavigationContainer } from '@react-navigation/native';
 import { createNativeStackNavigator } from '@react-navigation/native-stack';
 import { SafeAreaProvider } from 'react-native-safe-area-context';
-<<<<<<< HEAD
-
-try {
-  require('./app/config.local');
-} catch {
-  // Optional local overrides for development only
-}
-
-=======
->>>>>>> d3018ae8 (feat(ui): tech-styled glass card with futuristic input fields)
 import { useColors, radii } from './app/lib/theme';
 
 import SignIn from './app/screens/SignIn';
@@ -30,18 +20,11 @@ import AppLock from './app/screens/AppLock';
 import RootTabs from './app/navigation/RootTabs';
 import LinkBank from './app/screens/LinkBank';
 import ForgotPassword from './app/screens/ForgotPassword';
-
-<<<<<<< HEAD
-=======
-// Optional local overrides for development only (silently ignored if missing)
-try {
-  require('./app/config.local');
-} catch {
-  // no-op
-}
-
->>>>>>> d3018ae8 (feat(ui): tech-styled glass card with futuristic input fields)
 const Stack = createNativeStackNavigator();
+
+if (__DEV__) {
+  void import('./app/config.local').catch(() => undefined);
+}
 
 export default function App() {
   const colors = useColors();

--- a/__tests__/sanity.test.js
+++ b/__tests__/sanity.test.js
@@ -1,13 +1,6 @@
-<<<<<<< HEAD
-import assert from 'node:assert/strict';
 import test from 'node:test';
+import assert from 'node:assert/strict';
 
 test('sanity check runs', () => {
-=======
-import test from 'node:test';
-import assert from 'node:assert/strict';
-
-test('sanity check', () => {
->>>>>>> d3018ae8 (feat(ui): tech-styled glass card with futuristic input fields)
   assert.equal(true, true);
 });

--- a/app/lib/theme.js
+++ b/app/lib/theme.js
@@ -34,11 +34,11 @@ export const useColors = () => {
       cardBorder: 'rgba(130, 115, 255, 0.36)',
       cardOutline: 'rgba(255, 255, 255, 0.08)',
       danger: '#FF6F91',
+      inputBackground: 'rgba(9, 14, 29, 0.6)',
     };
   }
 
   return {
-<<<<<<< HEAD
     ...shared,
     bg: '#FFFFFF',
     bgSecondary: '#F2F2F7',
@@ -49,29 +49,6 @@ export const useColors = () => {
     cardBorder: 'rgba(130, 115, 255, 0.24)',
     cardOutline: 'rgba(161, 140, 255, 0.16)',
     danger: '#D93F6E',
-=======
-    // Backgrounds
-    bg: isDark ? '#000000' : '#FFFFFF',
-    background: isDark ? '#05060b' : '#f8f9ff',
-    bgSecondary: isDark ? '#121212' : '#F2F2F7',
-    bgGradient: isDark
-      ? ['#0f0f0f', '#1a1a1a', '#222831']
-      : ['#ffffff', '#f4f4f4', '#eaeaea'],
-
-    // Text
-    text: isDark ? '#EAEAEA' : '#1A1A1A',
-    subtext: isDark ? 'rgba(234, 234, 234, 0.7)' : 'rgba(38, 44, 64, 0.72)',
-    danger: '#FF6B6B',
-
-    // Accent
-    accent1: '#A18CFF', // purple gradient
-    accent2: '#58D5F7', // blue gradient
-
-    // Surfaces
-    card: isDark ? 'rgba(9, 14, 31, 0.68)' : 'rgba(255, 255, 255, 0.78)',
-    cardBorder: isDark ? 'rgba(88, 213, 247, 0.35)' : 'rgba(88, 213, 247, 0.2)',
-    cardOutline: isDark ? 'rgba(161, 140, 255, 0.4)' : 'rgba(161, 140, 255, 0.16)',
-    inputBackground: isDark ? 'rgba(9, 14, 29, 0.6)' : 'rgba(255, 255, 255, 0.88)',
->>>>>>> d3018ae8 (feat(ui): tech-styled glass card with futuristic input fields)
+    inputBackground: 'rgba(255, 255, 255, 0.88)',
   };
 };

--- a/app/screens/AppLock.js
+++ b/app/screens/AppLock.js
@@ -1,13 +1,10 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
-<<<<<<< HEAD
-import { View, Text, Alert, AppState, Platform } from 'react-native';
-=======
 import { AppState, Alert, Platform, Text, View } from 'react-native';
->>>>>>> d3018ae8 (feat(ui): tech-styled glass card with futuristic input fields)
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { LinearGradient } from 'expo-linear-gradient';
 import * as LocalAuthentication from 'expo-local-authentication';
 import { useIsFocused } from '@react-navigation/native';
+
 import HLButton from '../components/HLButton';
 import { useColors, spacing } from '../lib/theme';
 
@@ -41,62 +38,25 @@ export default function AppLock({ navigation }) {
           console.warn('Biometric availability check failed', error);
         }
       } finally {
-<<<<<<< HEAD
-        if (mountedRef.current) setChecking(false);
-=======
         if (mountedRef.current) {
           setChecking(false);
         }
->>>>>>> d3018ae8 (feat(ui): tech-styled glass card with futuristic input fields)
       }
     })();
   }, []);
 
-  useEffect(() => {
-<<<<<<< HEAD
-    if (!isFocused || checking || !available || !enrolled) return;
-    const timeout = setTimeout(() => {
-      if (!promptingRef.current) promptAuth();
-    }, 250);
-    return () => clearTimeout(timeout);
-  }, [isFocused, checking, available, enrolled, promptAuth]);
-
-=======
-    if (!isFocused || !available || !enrolled) return;
-
-    const timer = setTimeout(() => {
-      if (!promptingRef.current) {
-        void promptAuth();
-      }
-    }, 250);
-
-    return () => clearTimeout(timer);
-  }, [isFocused, available, enrolled, promptAuth]);
-
->>>>>>> d3018ae8 (feat(ui): tech-styled glass card with futuristic input fields)
-  useEffect(() => {
-    const sub = AppState.addEventListener('change', (state) => {
-      if (state === 'active') {
-        promptingRef.current = false;
-      }
-    });
-
-    return () => sub.remove();
-  }, []);
-
   const promptAuth = useCallback(async () => {
     try {
-      if (promptingRef.current || checking) return;
+      if (promptingRef.current || checking) {
+        return;
+      }
+
       promptingRef.current = true;
 
       if (!available || !enrolled) {
         Alert.alert(
           'Biometrics unavailable',
-<<<<<<< HEAD
           'Enable Face ID or Touch ID in your device settings to unlock HustleLedger.',
-=======
-          'Set up Face ID or Touch ID in your system settings to unlock HustleLedger.'
->>>>>>> d3018ae8 (feat(ui): tech-styled glass card with futuristic input fields)
         );
         return;
       }
@@ -108,7 +68,9 @@ export default function AppLock({ navigation }) {
         requireConfirmation: false,
       });
 
-      if (!mountedRef.current) return;
+      if (!mountedRef.current) {
+        return;
+      }
 
       if (result.success) {
         setTimeout(() => {
@@ -121,62 +83,35 @@ export default function AppLock({ navigation }) {
       if (__DEV__) {
         console.warn('Biometric authentication failed', error);
       }
-<<<<<<< HEAD
-      Alert.alert('Error', 'Could not start authentication.');
+      Alert.alert('Error', 'Could not start authentication. Please try again.');
     } finally {
       promptingRef.current = false;
     }
   }, [available, checking, enrolled, navigation]);
 
-  return (
-    <LinearGradient
-      colors={[colors.bg, colors.bgSecondary ?? colors.bg]}
-      start={{ x: 0, y: 0 }}
-      end={{ x: 1, y: 1 }}
-      style={{ flex: 1 }}
-    >
-      <SafeAreaView style={{ flex: 1, padding: spacing(3) }}>
-        <View
-          style={{ flex: 1, justifyContent: 'center', gap: spacing(2) }}
-          accessibilityLabel="Biometric unlock"
-          accessibilityRole="summary"
-        >
-          <Text
-            style={{
-              color: colors.text,
-              fontSize: 22,
-              fontWeight: '700',
-              textAlign: 'center',
-            }}
-            allowFontScaling
-          >
-            Secure Command Center
-          </Text>
-          <Text
-            style={{
-              color: colors.subtext ?? 'rgba(231, 236, 255, 0.76)',
-              textAlign: 'center',
-              lineHeight: 20,
-            }}
-            allowFontScaling
-          >
-            Authenticate with Face ID to resume your AI-guided wealth strategy.
-          </Text>
-          <HLButton
-            title={checking ? 'Preparing…' : 'Unlock'}
-            onPress={promptAuth}
-            accessibilityLabel="Unlock HustleLedger"
-            disabled={checking}
-          />
-        </View>
-      </SafeAreaView>
-    </LinearGradient>
-=======
-      Alert.alert('Error', 'Could not start authentication. Please try again.');
-    } finally {
-      promptingRef.current = false;
+  useEffect(() => {
+    if (!isFocused || checking || !available || !enrolled) {
+      return;
     }
-  }, [available, enrolled, navigation]);
+
+    const timer = setTimeout(() => {
+      if (!promptingRef.current) {
+        void promptAuth();
+      }
+    }, 250);
+
+    return () => clearTimeout(timer);
+  }, [isFocused, checking, available, enrolled, promptAuth]);
+
+  useEffect(() => {
+    const sub = AppState.addEventListener('change', (state) => {
+      if (state === 'active') {
+        promptingRef.current = false;
+      }
+    });
+
+    return () => sub.remove();
+  }, []);
 
   const helperText = !available
     ? 'Biometric hardware is not available on this device.'
@@ -185,22 +120,36 @@ export default function AppLock({ navigation }) {
     : 'Use biometrics to keep your data encrypted.';
 
   return (
-    <SafeAreaView style={{ flex: 1, backgroundColor: colors.bg }}>
-      <LinearGradient
-        colors={[colors.bg, colors.bgSecondary]}
-        start={{ x: 0, y: 0 }}
-        end={{ x: 1, y: 1 }}
-        style={{ flex: 1, padding: spacing(3), justifyContent: 'center' }}
-      >
-        <View style={{ gap: spacing(2) }}>
-          <Text style={{ color: colors.text, fontSize: 24, fontWeight: '700' }}>
+    <LinearGradient
+      colors={[colors.bg, colors.bgSecondary ?? colors.bg]}
+      start={{ x: 0, y: 0 }}
+      end={{ x: 1, y: 1 }}
+      style={{ flex: 1 }}
+    >
+      <SafeAreaView style={{ flex: 1 }}>
+        <View
+          style={{ flex: 1, padding: spacing(3), justifyContent: 'center', gap: spacing(2) }}
+          accessibilityLabel="Biometric unlock"
+          accessibilityRole="summary"
+        >
+          <Text
+            style={{
+              color: colors.text,
+              fontSize: 24,
+              fontWeight: '700',
+              textAlign: 'center',
+            }}
+            allowFontScaling
+          >
             Authenticate to continue
           </Text>
+
           {!checking && (
-            <Text style={{ color: colors.subtext, fontSize: 15, lineHeight: 20 }}>
+            <Text style={{ color: colors.subtext, fontSize: 15, lineHeight: 20 }} allowFontScaling>
               {helperText}
             </Text>
           )}
+
           <HLButton
             title={checking ? 'Checking biometrics…' : 'Unlock with Face ID'}
             onPress={promptAuth}
@@ -208,8 +157,7 @@ export default function AppLock({ navigation }) {
             accessibilityLabel="Unlock HustleLedger with biometrics"
           />
         </View>
-      </LinearGradient>
-    </SafeAreaView>
->>>>>>> d3018ae8 (feat(ui): tech-styled glass card with futuristic input fields)
+      </SafeAreaView>
+    </LinearGradient>
   );
 }

--- a/app/screens/SignIn.js
+++ b/app/screens/SignIn.js
@@ -2,491 +2,199 @@ import { useEffect, useState } from 'react';
 import {
   KeyboardAvoidingView,
   Platform,
-  View,
-  Text as RNText,
   ScrollView,
+  View,
   Pressable,
 } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { LinearGradient } from 'expo-linear-gradient';
 import { StatusBar } from 'expo-status-bar';
-import Animated, {
-  Easing,
-  interpolate,
-  useAnimatedStyle,
-  useSharedValue,
-  withDelay,
-  withRepeat,
-  withTiming,
-} from 'react-native-reanimated';
-import { TextInput, Text, Chip } from 'react-native-paper';
+import { TextInput, Text } from 'react-native-paper';
 import { onAuthStateChanged, signInWithEmailAndPassword } from 'firebase/auth';
 import * as Haptics from 'expo-haptics';
+
 import { auth } from '../lib/firebase';
 import GlassCard from '../components/GlassCard';
 import HLButton from '../components/HLButton';
 import { useColors, useIsDarkMode, spacing, radii } from '../lib/theme';
 
-const AnimatedGradient = Animated.createAnimatedComponent(LinearGradient);
-
 export default function SignIn({ navigation }) {
   const colors = useColors();
   const isDark = useIsDarkMode();
   const [email, setEmail] = useState('');
-  const [pw, setPw] = useState('');
-  const [err, setErr] = useState('');
+  const [password, setPassword] = useState('');
+  const [error, setError] = useState('');
   const [loading, setLoading] = useState(false);
-  const [focusedField, setFocusedField] = useState(null);
-
-  const subtextColor = colors.subtext ?? (isDark ? 'rgba(231, 236, 255, 0.76)' : 'rgba(22, 30, 62, 0.72)');
-  const cardBorder = colors.cardBorder ?? 'rgba(130, 115, 255, 0.36)';
-  const dangerColor = colors.danger ?? '#FF6F91';
-  const gradientStops = isDark
-    ? ['#040510', '#10133a', '#261d52']
-    : ['#f3f5ff', '#dfe7ff', '#cfdafe'];
-
-  const particleConfigs = useMemo(
-    () => [
-      { size: 12, left: '14%', delay: 0, duration: 7200 },
-      { size: 20, left: '48%', delay: 900, duration: 6800 },
-      { size: 10, left: '78%', delay: 1500, duration: 7600 },
-    ],
-    [],
-  );
 
   useEffect(() => {
-    const unsub = onAuthStateChanged(auth, (u) => {
-      if (u) navigation.replace('AppLock');
+    const unsubscribe = onAuthStateChanged(auth, (user) => {
+      if (user) {
+        navigation.replace('AppLock');
+      }
     });
-    return () => unsub();
+
+    return () => unsubscribe();
   }, [navigation]);
 
-  const handleFocus = (fieldKey) => {
-    setFocusedField(fieldKey);
-    Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light).catch(() => {});
-  };
+  const gradientStops = isDark
+    ? [colors.bg ?? '#02030A', colors.bgSecondary ?? '#0B0F23']
+    : [colors.bg ?? '#FFFFFF', colors.bgSecondary ?? '#F2F2F7'];
 
-  const handleBlur = () => {
-    setFocusedField(null);
-    Haptics.selectionAsync().catch(() => {});
-  };
-
-  const onSignIn = async () => {
-    setErr('');
+  const onSubmit = async () => {
+    setError('');
     setLoading(true);
     try {
-      await signInWithEmailAndPassword(auth, email.trim(), pw);
+      await signInWithEmailAndPassword(auth, email.trim(), password);
+      Haptics.notificationAsync(Haptics.NotificationFeedbackType.Success).catch(() => {});
       navigation.replace('AppLock');
-    } catch (error) {
-      setErr(error?.message || 'Sign in failed');
+    } catch (err) {
+      Haptics.notificationAsync(Haptics.NotificationFeedbackType.Error).catch(() => {});
+      setError(err?.message ?? 'Unable to sign in. Please try again.');
     } finally {
       setLoading(false);
     }
   };
 
-  const inputTheme = {
-    colors: {
-      onSurfaceVariant: subtextColor,
-      primary: colors.accent1,
-    },
-  };
-
-  const badgeBackground = isDark ? 'rgba(12, 16, 48, 0.45)' : 'rgba(240, 244, 255, 0.6)';
-  const secondaryLinkBg = isDark ? 'rgba(12, 16, 48, 0.24)' : 'rgba(247, 249, 255, 0.72)';
-  const secondaryLinkText = isDark ? '#A18CFF' : '#5B4FE6';
-  const taglineColor = isDark ? 'rgba(214, 220, 255, 0.66)' : 'rgba(34, 44, 86, 0.6)';
-
   return (
-    <KeyboardAvoidingView
-      style={styles.flex}
-      behavior={Platform.OS === 'ios' ? 'padding' : undefined}
+    <LinearGradient
+      colors={gradientStops}
+      start={{ x: 0, y: 0 }}
+      end={{ x: 1, y: 1 }}
+      style={{ flex: 1 }}
     >
-      <LinearGradient
-        colors={gradientStops}
-        start={{ x: 0, y: 0 }}
-        end={{ x: 1, y: 1 }}
-        style={styles.flex}
-      >
+      <SafeAreaView style={{ flex: 1 }}>
         <StatusBar style={isDark ? 'light' : 'dark'} />
-        <AnimatedParticles
-          configs={particleConfigs}
-          fillColor={isDark ? 'rgba(161, 140, 255, 0.4)' : 'rgba(96, 128, 255, 0.35)'}
-          shadowColor={isDark ? '#58D5F7' : '#7AA7FF'}
-          gridColors={
-            isDark
-              ? ['rgba(161, 140, 255, 0.12)', 'transparent', 'rgba(88, 213, 247, 0.16)']
-              : ['rgba(95, 136, 255, 0.12)', 'transparent', 'rgba(101, 231, 254, 0.18)']
-          }
-        />
-
-            <GlassCard accessibilityLabel="Sign in to HustleLedger command deck">
-              <LinearGradient
-                colors={[`${colors.accent1}22`, `${colors.accent2}11`]}
-                start={{ x: 0, y: 0 }}
-                end={{ x: 1, y: 1 }}
-                style={{
-                  borderRadius: radii.lg,
-                  padding: spacing(1.75),
-                  marginBottom: spacing(2.5),
-                  backgroundColor: 'rgba(255,255,255,0.04)',
-                }}
-              >
-                <Text style={{ color: colors.subtext, fontSize: 13, lineHeight: 18 }}>
-                  HustleLedger syncs your accounts in real time with our AI engine. Banking-grade encryption keeps your data safe.
+        <KeyboardAvoidingView
+          style={{ flex: 1 }}
+          behavior={Platform.OS === 'ios' ? 'padding' : undefined}
+        >
+          <ScrollView
+            contentContainerStyle={{
+              flexGrow: 1,
+              padding: spacing(3),
+              justifyContent: 'center',
+            }}
+            keyboardShouldPersistTaps="handled"
+          >
+            <View style={{ gap: spacing(2) }}>
+              <View style={{ alignItems: 'center', gap: spacing(1) }}>
+                <Text
+                  variant="headlineMedium"
+                  style={{ color: colors.text, fontWeight: '700', textAlign: 'center' }}
+                  allowFontScaling
+                >
+                  Welcome back to HustleLedger
+                </Text>
+                <Text
+                  style={{
+                    color: colors.subtext,
+                    textAlign: 'center',
+                    maxWidth: 320,
+                  }}
+                  allowFontScaling
+                >
+                  Sign in to orchestrate your cash flow automations and stay ahead of every hustle.
                 </Text>
               </View>
 
-              <View style={{ marginBottom: spacing(2) }}>
-                <View
-                  style={{
-                    borderRadius: radii.md,
-                    backgroundColor: colors.inputBackground,
-                    borderWidth: 1,
-                    borderColor:
-                      focusedField === 'email'
-                        ? `${colors.accent2}88`
-                        : colors.cardOutline,
-                    overflow: 'hidden',
-                  }}
-                >
-                  <TextInput
-                    label="Your Access ID"
-                    value={email}
-                    onChangeText={setEmail}
-                    autoCapitalize="none"
-                    keyboardType="email-address"
-                    onFocus={() => handleFocus('email')}
-                    onBlur={handleBlur}
-                    mode="flat"
-                    left={
-                      <TextInput.Icon
-                        icon="email-outline"
-                        color={focusedField === 'email' ? colors.accent2 : colors.subtext}
-                      />
-                    }
-                    textColor={colors.text}
-                    style={{ backgroundColor: 'transparent' }}
-                    contentStyle={{ fontSize: 16 }}
-                    underlineColor="transparent"
-                    activeUnderlineColor="transparent"
-                    theme={{ colors: { onSurfaceVariant: colors.subtext } }}
-                    accessibilityLabel="Enter your email"
+              <GlassCard accessibilityLabel="Sign in form">
+                <View style={{ gap: spacing(2) }}>
+                  <View
+                    style={{
+                      borderRadius: radii.md,
+                      backgroundColor: colors.inputBackground,
+                      borderWidth: 1,
+                      borderColor: colors.cardOutline,
+                    }}
+                  >
+                    <TextInput
+                      label="Email"
+                      value={email}
+                      onChangeText={setEmail}
+                      keyboardType="email-address"
+                      autoCapitalize="none"
+                      autoCorrect={false}
+                      textContentType="username"
+                      mode="flat"
+                      style={{ backgroundColor: 'transparent' }}
+                      underlineColor="transparent"
+                      activeUnderlineColor="transparent"
+                      theme={{ colors: { onSurfaceVariant: colors.subtext, primary: colors.accent1 } }}
+                      accessibilityLabel="Enter your email address"
+                    />
+                  </View>
+
+                  <View
+                    style={{
+                      borderRadius: radii.md,
+                      backgroundColor: colors.inputBackground,
+                      borderWidth: 1,
+                      borderColor: colors.cardOutline,
+                    }}
+                  >
+                    <TextInput
+                      label="Password"
+                      value={password}
+                      onChangeText={setPassword}
+                      secureTextEntry
+                      textContentType="password"
+                      mode="flat"
+                      style={{ backgroundColor: 'transparent' }}
+                      underlineColor="transparent"
+                      activeUnderlineColor="transparent"
+                      theme={{ colors: { onSurfaceVariant: colors.subtext, primary: colors.accent1 } }}
+                      accessibilityLabel="Enter your password"
+                    />
+                  </View>
+
+                  {error ? (
+                    <Text style={{ color: colors.danger, textAlign: 'center' }} allowFontScaling>
+                      {error}
+                    </Text>
+                  ) : null}
+
+                  <HLButton
+                    title={loading ? 'Signing in…' : 'Sign in'}
+                    onPress={onSubmit}
+                    accessibilityLabel="Sign in to HustleLedger"
+                    disabled={loading}
                   />
+
+                  <Pressable
+                    onPress={() => navigation.navigate('ForgotPassword')}
+                    style={{ alignSelf: 'flex-end' }}
+                    accessibilityRole="button"
+                    accessibilityLabel="Forgot your password"
+                  >
+                    <Text style={{ color: colors.accent2, fontWeight: '600' }} allowFontScaling>
+                      Forgot password?
+                    </Text>
+                  </Pressable>
                 </View>
-                <LinearGradient
-                  colors={
-                    focusedField === 'email'
-                      ? [colors.accent1, colors.accent2]
-                      : ['rgba(161, 140, 255, 0.35)', 'rgba(88, 213, 247, 0.35)']
-                  }
-                  start={{ x: 0, y: 0 }}
-                  end={{ x: 1, y: 0 }}
-                  style={{
-                    height: 3,
-                    borderRadius: 999,
-                    marginTop: spacing(0.5),
-                    opacity: focusedField === 'email' ? 1 : 0.5,
-                  }}
-                />
-              </View>
-
-              <View style={{ marginBottom: spacing(1.5) }}>
-                <View
-                  style={{
-                    borderRadius: radii.md,
-                    backgroundColor: colors.inputBackground,
-                    borderWidth: 1,
-                    borderColor:
-                      focusedField === 'password'
-                        ? `${colors.accent1}88`
-                        : colors.cardBorder,
-                    overflow: 'hidden',
-                  }}
-                >
-                  <TextInput
-                    label="Secure Key"
-                    value={pw}
-                    onChangeText={setPw}
-                    secureTextEntry
-                    textContentType="oneTimeCode"
-                    onFocus={() => handleFocus('password')}
-                    onBlur={handleBlur}
-                    mode="flat"
-                    left={
-                      <TextInput.Icon
-                        icon="lock-outline"
-                        color={focusedField === 'password' ? colors.accent1 : colors.subtext}
-                      />
-                    }
-                    textColor={colors.text}
-                    style={{ backgroundColor: 'transparent' }}
-                    contentStyle={{ fontSize: 16 }}
-                    underlineColor="transparent"
-                    activeUnderlineColor="transparent"
-                    theme={{ colors: { onSurfaceVariant: colors.subtext } }}
-                    accessibilityLabel="Enter your password"
-                  />
-                </View>
-                <LinearGradient
-                  colors={
-                    focusedField === 'password'
-                      ? [colors.accent2, colors.accent1]
-                      : ['rgba(88, 213, 247, 0.35)', 'rgba(161, 140, 255, 0.35)']
-                  }
-                  start={{ x: 0, y: 0 }}
-                  end={{ x: 1, y: 0 }}
-                  style={{
-                    height: 3,
-                    borderRadius: 999,
-                    marginTop: spacing(0.5),
-                    opacity: focusedField === 'password' ? 1 : 0.5,
-                  }}
-                />
-              </View>
-
-              <Pressable
-                onPress={() => navigation.navigate('ForgotPassword')}
-                style={{ alignSelf: 'flex-end', marginBottom: spacing(2) }}
-                accessibilityRole="button"
-                accessibilityLabel="Recover your secure key"
-              >
-                <Text style={{ color: colors.accent2, fontWeight: '600' }}>Forgot Secure Key?</Text>
-              </Pressable>
-
-                <TextInput
-                  label="Password"
-                  value={pw}
-                  onChangeText={setPw}
-                  secureTextEntry
-                  textContentType="oneTimeCode"
-                  style={styles.input}
-                  mode="flat"
-                  theme={inputTheme}
-                  accessibilityLabel="Password"
-                />
-
-                {!!err && (
-                  <Text style={{ color: dangerColor, marginBottom: spacing(1) }} allowFontScaling>
-                    {err}
-                  </Text>
-                )}
-
-                <HLButton
-                  title={loading ? 'Signing in…' : 'Enter Command Center'}
-                  onPress={onSignIn}
-                  accessibilityLabel="Sign in to HustleLedger"
-                />
               </GlassCard>
 
               <Pressable
                 onPress={() => navigation.replace('SignUp')}
                 accessibilityRole="link"
-                accessibilityLabel="Create your HustleLedger account"
-                style={({ pressed }) => [
-                  styles.secondaryLink,
-                  {
-                    backgroundColor: secondaryLinkBg,
-                    shadowColor: colors.accent1,
-                    opacity: pressed ? 0.75 : 1,
-                  },
-                ]}
+                accessibilityLabel="Create a HustleLedger account"
+                style={({ pressed }) => ({
+                  alignSelf: 'center',
+                  paddingVertical: spacing(1),
+                  paddingHorizontal: spacing(2.5),
+                  borderRadius: radii.lg,
+                  borderWidth: 1,
+                  borderColor: colors.cardBorder,
+                  opacity: pressed ? 0.8 : 1,
+                })}
               >
-                <Text
-                  style={[
-                    styles.secondaryLinkText,
-                    { color: secondaryLinkText },
-                  ]}
-                  allowFontScaling
-                >
-                  Create Your Account
+                <Text style={{ color: colors.accent1, fontWeight: '600' }} allowFontScaling>
+                  Need an account? Join HustleLedger
                 </Text>
               </Pressable>
-
-              <RNText
-                style={[
-                  styles.tagline,
-                  { color: taglineColor },
-                ]}
-                allowFontScaling
-              >
-                Banking-grade security. AI-driven growth.
-              </RNText>
             </View>
           </ScrollView>
-        </SafeAreaView>
-      </LinearGradient>
-    </KeyboardAvoidingView>
+        </KeyboardAvoidingView>
+      </SafeAreaView>
+    </LinearGradient>
   );
 }
-
-function AnimatedParticles({ configs, fillColor, shadowColor, gridColors }) {
-  return (
-    <View pointerEvents="none" style={styles.particleContainer}>
-      {configs.map((config, index) => (
-        <Particle key={index} {...config} fillColor={fillColor} shadowColor={shadowColor} />
-      ))}
-      <AnimatedGridlines gridColors={gridColors} />
-    </View>
-  );
-}
-
-function Particle({ size, left, delay, duration, fillColor, shadowColor }) {
-  const progress = useSharedValue(0);
-
-  useEffect(() => {
-    progress.value = withRepeat(
-      withDelay(
-        delay,
-        withTiming(1, {
-          duration,
-          easing: Easing.inOut(Easing.quad),
-        }),
-      ),
-      -1,
-      false,
-    );
-  }, [delay, duration, progress]);
-
-  const animatedStyle = useAnimatedStyle(() => ({
-    opacity: interpolate(progress.value, [0, 0.5, 1], [0, 0.65, 0]),
-    transform: [
-      {
-        translateY: interpolate(progress.value, [0, 1], [0, -80]),
-      },
-      {
-        translateX: interpolate(progress.value, [0, 0.5, 1], [0, 8, 0]),
-      },
-    ],
-  }));
-
-  return (
-    <Animated.View
-      style={[
-        styles.particle,
-        {
-          left,
-          width: size,
-          height: size,
-          borderRadius: size / 2,
-          backgroundColor: fillColor,
-          shadowColor,
-        },
-        animatedStyle,
-      ]}
-    />
-  );
-}
-
-function AnimatedGridlines({ gridColors }) {
-  const shimmer = useSharedValue(0);
-
-  useEffect(() => {
-    shimmer.value = withRepeat(withTiming(1, { duration: 9000, easing: Easing.linear }), -1, false);
-  }, [shimmer]);
-
-  const animatedStyle = useAnimatedStyle(() => ({
-    transform: [
-      {
-        translateX: interpolate(shimmer.value, [0, 1], [-24, 24]),
-      },
-    ],
-    opacity: interpolate(shimmer.value, [0, 0.5, 1], [0.12, 0.22, 0.12]),
-  }));
-
-  return (
-    <AnimatedGradient
-      colors={gridColors}
-      start={{ x: 0, y: 0 }}
-      end={{ x: 1, y: 1 }}
-      style={[styles.gridlines, animatedStyle]}
-    />
-  );
-}
-
-const styles = StyleSheet.create({
-  flex: { flex: 1 },
-  contentWrapper: {
-    flex: 1,
-    justifyContent: 'center',
-  },
-  heroArea: {
-    marginBottom: spacing(3),
-    alignItems: 'center',
-    gap: spacing(1.5),
-  },
-  badgeGlow: {
-    padding: 2,
-    borderRadius: radii.xl,
-    alignSelf: 'center',
-  },
-  badge: {
-    borderRadius: radii.xl,
-    borderWidth: 1,
-    paddingHorizontal: spacing(1.5),
-  },
-  brandTitle: {
-    fontSize: 36,
-    fontWeight: '800',
-    letterSpacing: 2,
-    textAlign: 'center',
-    marginTop: spacing(2),
-  },
-  heroHeadline: {
-    fontSize: 28,
-    fontWeight: '700',
-    textAlign: 'center',
-  },
-  heroDescription: {
-    marginTop: spacing(1),
-    lineHeight: 22,
-    fontSize: 15,
-    textAlign: 'center',
-    maxWidth: 320,
-  },
-  helperGradient: {
-    borderRadius: radii.lg,
-    padding: spacing(1.5),
-    marginBottom: spacing(2),
-    backgroundColor: 'rgba(255,255,255,0.04)',
-  },
-  input: {
-    marginBottom: spacing(1.5),
-    backgroundColor: 'transparent',
-  },
-  secondaryLink: {
-    alignSelf: 'center',
-    marginTop: spacing(3),
-    borderRadius: radii.xl,
-    paddingVertical: spacing(1),
-    paddingHorizontal: spacing(2.5),
-    shadowOffset: { width: 0, height: 6 },
-    shadowRadius: 14,
-  },
-  secondaryLinkText: {
-    fontWeight: '600',
-    fontSize: 15,
-  },
-  tagline: {
-    textAlign: 'center',
-    marginTop: spacing(4),
-    fontSize: 12,
-    letterSpacing: 0.8,
-  },
-  particleContainer: {
-    ...StyleSheet.absoluteFillObject,
-  },
-  particle: {
-    position: 'absolute',
-    shadowRadius: 12,
-    shadowOpacity: 0.45,
-    shadowOffset: { width: 0, height: 0 },
-  },
-  gridlines: {
-    position: 'absolute',
-    top: '-25%',
-    left: '-20%',
-    right: '-20%',
-    bottom: '-25%',
-    borderRadius: radii.xl,
-  },
-});

--- a/app/screens/Welcome.js
+++ b/app/screens/Welcome.js
@@ -1,0 +1,173 @@
+import { useMemo } from 'react';
+import { View, Text, Pressable, StyleSheet, Platform } from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
+import { StatusBar } from 'expo-status-bar';
+import { LinearGradient } from 'expo-linear-gradient';
+import GlassCard from '../components/GlassCard';
+import HLButton from '../components/HLButton';
+import { useColors, useIsDarkMode, spacing, radii } from '../lib/theme';
+
+const styles = StyleSheet.create({
+  flex: { flex: 1 },
+  container: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+    padding: spacing(2),
+  },
+  panel: {
+    width: '100%',
+    maxWidth: 420,
+    alignItems: 'center',
+    gap: spacing(2),
+  },
+  fallbackCard: {
+    backgroundColor: 'rgba(255,255,255,0.06)',
+    borderWidth: 1,
+    borderColor: 'rgba(255,255,255,0.12)',
+    borderRadius: radii.lg,
+    padding: spacing(3),
+    width: '100%',
+    alignItems: 'center',
+    ...Platform.select({
+      ios: {
+        shadowColor: '#000000',
+        shadowOpacity: 0.15,
+        shadowRadius: 18,
+        shadowOffset: { width: 0, height: 10 },
+      },
+      android: {
+        elevation: 12,
+      },
+      default: {},
+    }),
+  },
+  logoBadge: {
+    width: 72,
+    height: 72,
+    borderRadius: 36,
+    alignItems: 'center',
+    justifyContent: 'center',
+    borderWidth: 1,
+    borderColor: 'rgba(255,255,255,0.18)',
+  },
+  logoText: {
+    fontSize: 28,
+    fontWeight: '800',
+    color: '#050510',
+    letterSpacing: 2,
+  },
+  title: {
+    fontSize: 30,
+    fontWeight: '800',
+    textAlign: 'center',
+    lineHeight: 36,
+  },
+  tagline: {
+    fontSize: 16,
+    lineHeight: 24,
+    textAlign: 'center',
+  },
+  primaryAction: {
+    alignSelf: 'stretch',
+  },
+  secondaryAction: {
+    paddingVertical: spacing(1),
+    paddingHorizontal: spacing(2),
+  },
+  secondaryText: {
+    fontSize: 16,
+    fontWeight: '600',
+    textAlign: 'center',
+  },
+});
+
+function FallbackGlassCard({ children, style, accessibilityLabel }) {
+  return (
+    <View
+      style={[styles.fallbackCard, style]}
+      accessible
+      accessibilityRole="summary"
+      accessibilityLabel={accessibilityLabel}
+    >
+      {children}
+    </View>
+  );
+}
+
+export default function Welcome({ navigation }) {
+  const colors = useColors();
+  const isDark = useIsDarkMode();
+  const PanelComponent = GlassCard || FallbackGlassCard;
+
+  const badgeGradient = useMemo(
+    () => [colors.accent1 + 'AA', colors.accent2 + 'AA'],
+    [colors.accent1, colors.accent2],
+  );
+
+  return (
+    <SafeAreaView style={styles.flex}>
+      <StatusBar style={isDark ? 'light' : 'dark'} />
+      <LinearGradient
+        colors={[colors.bg, colors.cardBorder]}
+        start={{ x: 0, y: 0 }}
+        end={{ x: 1, y: 1 }}
+        style={styles.flex}
+      >
+        <View style={styles.container}>
+          <PanelComponent
+            style={styles.panel}
+            accessibilityLabel="HustleLedger welcome overview"
+          >
+            <LinearGradient
+              colors={badgeGradient}
+              start={{ x: 0, y: 0 }}
+              end={{ x: 1, y: 1 }}
+              style={styles.logoBadge}
+            >
+              <Text style={styles.logoText} accessibilityRole="text" allowFontScaling>
+                HL
+              </Text>
+            </LinearGradient>
+
+            <Text style={[styles.title, { color: colors.text }]} allowFontScaling>
+              Welcome to HustleLedger
+            </Text>
+            <Text
+              style={[styles.tagline, { color: colors.subtext }]}
+              allowFontScaling
+              accessibilityRole="text"
+            >
+              Your AI co-pilot for automating cash flow rituals, insights, and every hustle ledger entry.
+            </Text>
+
+            <HLButton
+              title="Enter command deck"
+              onPress={() => navigation?.navigate?.('SignIn')}
+              style={styles.primaryAction}
+              accessibilityLabel="Enter the HustleLedger command deck"
+            />
+            <Pressable
+              onPress={() => navigation?.navigate?.('SignUp')}
+              accessibilityRole="button"
+              accessibilityLabel="Create a HustleLedger account"
+              style={styles.secondaryAction}
+            >
+              {({ pressed }) => (
+                <Text
+                  style={[
+                    styles.secondaryText,
+                    { color: colors.accent1, opacity: pressed ? 0.8 : 1 },
+                  ]}
+                  allowFontScaling
+                >
+                  Create an account
+                </Text>
+              )}
+            </Pressable>
+          </PanelComponent>
+        </View>
+      </LinearGradient>
+    </SafeAreaView>
+  );
+}

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,24 +1,25 @@
 import { createRequire } from 'node:module';
 import { FlatCompat } from '@eslint/eslintrc';
-
-const require = createRequire(import.meta.url);
-const recommendedConfig = require('./config/eslint/eslint-recommended.cjs');
 import reactPlugin from 'eslint-plugin-react';
 import reactHooksPlugin from 'eslint-plugin-react-hooks';
 import reactNativePlugin from 'eslint-plugin-react-native';
 
+const require = createRequire(import.meta.url);
+const recommendedConfig = require('./config/eslint/eslint-recommended.cjs');
+
 const compat = new FlatCompat({
   baseDirectory: import.meta.dirname,
-  recommendedConfig
+  recommendedConfig,
 });
 
 export default [
   {
-    ignores: ['node_modules/**', 'android/**', 'vendor/**']
+    ignores: ['node_modules/**', 'android/**', 'vendor/**'],
   },
   ...compat.config({
-    extends: ['eslint:recommended']
+    extends: ['eslint:recommended'],
   }),
+  ...compat.config(recommendedConfig),
   {
     files: ['**/*.{js,jsx,ts,tsx}'],
     languageOptions: {
@@ -26,8 +27,8 @@ export default [
       sourceType: 'module',
       parserOptions: {
         ecmaFeatures: {
-          jsx: true
-        }
+          jsx: true,
+        },
       },
       globals: {
         __DEV__: 'readonly',
@@ -37,18 +38,18 @@ export default [
         requestAnimationFrame: 'readonly',
         require: 'readonly',
         setTimeout: 'readonly',
-        clearTimeout: 'readonly'
-      }
+        clearTimeout: 'readonly',
+      },
     },
     plugins: {
       react: reactPlugin,
       'react-hooks': reactHooksPlugin,
-      'react-native': reactNativePlugin
+      'react-native': reactNativePlugin,
     },
     settings: {
       react: {
-        version: 'detect'
-      }
+        version: 'detect',
+      },
     },
     rules: {
       'react/react-in-jsx-scope': 'off',
@@ -58,37 +59,20 @@ export default [
       'react-hooks/rules-of-hooks': 'error',
       'react-hooks/exhaustive-deps': 'warn',
       'react-native/no-unused-styles': 'error',
-      'react-native/no-inline-styles': 'off'
-    }
-  },
-  {
-<<<<<<< HEAD
-    files: ['.eslintrc.js', 'scripts/**/*.js'],
-    languageOptions: {
-      sourceType: 'script',
-      globals: {
-        console: 'readonly',
-        module: 'writable',
-        process: 'readonly',
-        require: 'readonly',
-        __dirname: 'readonly',
-      },
+      'react-native/no-inline-styles': 'off',
     },
   },
   {
-    files: ['babel.config.js'],
-=======
     files: ['babel.config.js', '.eslintrc.js'],
->>>>>>> d3018ae8 (feat(ui): tech-styled glass card with futuristic input fields)
     languageOptions: {
       sourceType: 'script',
       globals: {
         module: 'writable',
         require: 'readonly',
         __dirname: 'readonly',
-        process: 'readonly'
-      }
-    }
+        process: 'readonly',
+      },
+    },
   },
   {
     files: ['scripts/**/*.js'],
@@ -98,9 +82,9 @@ export default [
         console: 'readonly',
         module: 'readonly',
         process: 'readonly',
-        require: 'readonly'
-      }
-    }
+        require: 'readonly',
+      },
+    },
   },
   {
     files: ['**/__tests__/**/*.{js,jsx,ts,tsx}', '**/*.test.{js,jsx,ts,tsx}'],
@@ -110,18 +94,18 @@ export default [
         it: 'readonly',
         expect: 'readonly',
         beforeEach: 'readonly',
-        jest: 'readonly'
-      }
-    }
+        jest: 'readonly',
+      },
+    },
   },
   {
     files: ['testing/**/*.mjs'],
     languageOptions: {
       sourceType: 'module',
       globals: {
-        URL: 'readonly'
-      }
-    }
+        URL: 'readonly',
+      },
+    },
   },
   {
     files: ['testing/**/*.cjs'],
@@ -132,8 +116,8 @@ export default [
         module: 'readonly',
         process: 'readonly',
         require: 'readonly',
-        __dirname: 'readonly'
-      }
-    }
-  }
+        __dirname: 'readonly',
+      },
+    },
+  },
 ];


### PR DESCRIPTION
## Summary
- load optional local overrides via dynamic import while keeping the stack navigator intact
- refresh the theme palette and biometric AppLock flow to reliably prompt users with contextual helper text
- rebuild the sign-in experience with an accessible glass card form and align the ESLint/test harness configuration

## Testing
- `npx eslint .`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68d9cd007aa083229aa9981fde572722