### PR TITLE
Add welcome screen and smoke test harness

### DIFF
--- a/App.js
+++ b/App.js
@@ -12,18 +12,9 @@ import {
 import { NavigationContainer } from '@react-navigation/native';
 import { createNativeStackNavigator } from '@react-navigation/native-stack';
 import { SafeAreaProvider } from 'react-native-safe-area-context';
-<<<<<<< HEAD
-
-try {
-  require('./app/config.local');
-} catch {
-  // Optional local overrides for development only
-}
-
-=======
->>>>>>> d3018ae8 (feat(ui): tech-styled glass card with futuristic input fields)
 import { useColors, radii } from './app/lib/theme';
 
+import Welcome from './app/screens/Welcome';
 import SignIn from './app/screens/SignIn';
 import SignUp from './app/screens/SignUp';
 import AppLock from './app/screens/AppLock';
@@ -31,16 +22,12 @@ import RootTabs from './app/navigation/RootTabs';
 import LinkBank from './app/screens/LinkBank';
 import ForgotPassword from './app/screens/ForgotPassword';
 
-<<<<<<< HEAD
-=======
-// Optional local overrides for development only (silently ignored if missing)
 try {
   require('./app/config.local');
 } catch {
-  // no-op
+  // Optional local overrides for development only
 }
 
->>>>>>> d3018ae8 (feat(ui): tech-styled glass card with futuristic input fields)
 const Stack = createNativeStackNavigator();
 
 export default function App() {
@@ -88,6 +75,7 @@ export default function App() {
           >
             <NavigationContainer>
               <Stack.Navigator screenOptions={{ headerShown: false, animation: 'fade_from_bottom' }}>
+                <Stack.Screen name="Welcome" component={Welcome} />
                 <Stack.Screen name="SignIn" component={SignIn} />
                 <Stack.Screen name="SignUp" component={SignUp} />
                 <Stack.Screen name="AppLock" component={AppLock} />

--- a/__tests__/sanity.test.js
+++ b/__tests__/sanity.test.js
@@ -1,13 +1,6 @@
-<<<<<<< HEAD
-import assert from 'node:assert/strict';
 import test from 'node:test';
+import assert from 'node:assert/strict';
 
 test('sanity check runs', () => {
-=======
-import test from 'node:test';
-import assert from 'node:assert/strict';
-
-test('sanity check', () => {
->>>>>>> d3018ae8 (feat(ui): tech-styled glass card with futuristic input fields)
   assert.equal(true, true);
 });

--- a/app/__tests__/Welcome.test.js
+++ b/app/__tests__/Welcome.test.js
@@ -1,0 +1,74 @@
+import React from 'react';
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { render, fireEvent } from '@testing-library/react-native';
+
+const NavigationContainer = ({ children }) => React.createElement(React.Fragment, null, children);
+
+const DummyStack = {
+  Navigator: ({ children }) => React.createElement(React.Fragment, null, children),
+  Screen: ({ name, children, component: Component }) => {
+    const navigation = {
+      navigate: () => {},
+      replace: () => {},
+      push: () => {},
+      pop: () => {},
+      popToTop: () => {},
+      goBack: () => {},
+      setParams: () => {},
+      setOptions: () => {},
+    };
+    const route = { key: name ?? 'screen', name: name ?? 'Screen', params: {} };
+
+    if (typeof children === 'function') {
+      return children({ navigation, route });
+    }
+
+    if (Component) {
+      return React.createElement(Component, { navigation, route });
+    }
+
+    return null;
+  },
+};
+
+const Placeholder = () => null;
+
+test('Welcome shows auth actions and navigates to sign in', async (t) => {
+  const module = await import('../screens/Welcome.js');
+  const Welcome = module.default ?? module;
+
+  const navigate = t.mock.fn();
+
+  const { findByText, getByText } = render(
+    React.createElement(
+      NavigationContainer,
+      null,
+      React.createElement(
+        DummyStack.Navigator,
+        null,
+        React.createElement(DummyStack.Screen, {
+          name: 'Welcome',
+          children: (props) =>
+            React.createElement(Welcome, {
+              ...props,
+              navigation: { ...props.navigation, navigate },
+            }),
+        }),
+        React.createElement(DummyStack.Screen, { name: 'SignIn', component: Placeholder }),
+        React.createElement(DummyStack.Screen, { name: 'SignUp', component: Placeholder }),
+      ),
+    ),
+  );
+
+  const signInButton = await findByText('Sign In');
+  const createAccountButton = getByText('Create account');
+
+  assert.ok(signInButton);
+  assert.ok(createAccountButton);
+
+  fireEvent.press(signInButton);
+
+  assert.equal(navigate.mock.callCount(), 1);
+  assert.deepEqual(navigate.mock.calls[0].arguments, ['SignIn']);
+});

--- a/app/lib/theme.js
+++ b/app/lib/theme.js
@@ -38,7 +38,6 @@ export const useColors = () => {
   }
 
   return {
-<<<<<<< HEAD
     ...shared,
     bg: '#FFFFFF',
     bgSecondary: '#F2F2F7',
@@ -48,30 +47,7 @@ export const useColors = () => {
     card: 'rgba(255, 255, 255, 0.88)',
     cardBorder: 'rgba(130, 115, 255, 0.24)',
     cardOutline: 'rgba(161, 140, 255, 0.16)',
+    inputBackground: 'rgba(255, 255, 255, 0.88)',
     danger: '#D93F6E',
-=======
-    // Backgrounds
-    bg: isDark ? '#000000' : '#FFFFFF',
-    background: isDark ? '#05060b' : '#f8f9ff',
-    bgSecondary: isDark ? '#121212' : '#F2F2F7',
-    bgGradient: isDark
-      ? ['#0f0f0f', '#1a1a1a', '#222831']
-      : ['#ffffff', '#f4f4f4', '#eaeaea'],
-
-    // Text
-    text: isDark ? '#EAEAEA' : '#1A1A1A',
-    subtext: isDark ? 'rgba(234, 234, 234, 0.7)' : 'rgba(38, 44, 64, 0.72)',
-    danger: '#FF6B6B',
-
-    // Accent
-    accent1: '#A18CFF', // purple gradient
-    accent2: '#58D5F7', // blue gradient
-
-    // Surfaces
-    card: isDark ? 'rgba(9, 14, 31, 0.68)' : 'rgba(255, 255, 255, 0.78)',
-    cardBorder: isDark ? 'rgba(88, 213, 247, 0.35)' : 'rgba(88, 213, 247, 0.2)',
-    cardOutline: isDark ? 'rgba(161, 140, 255, 0.4)' : 'rgba(161, 140, 255, 0.16)',
-    inputBackground: isDark ? 'rgba(9, 14, 29, 0.6)' : 'rgba(255, 255, 255, 0.88)',
->>>>>>> d3018ae8 (feat(ui): tech-styled glass card with futuristic input fields)
   };
 };

--- a/app/screens/AppLock.js
+++ b/app/screens/AppLock.js
@@ -1,9 +1,5 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
-<<<<<<< HEAD
-import { View, Text, Alert, AppState, Platform } from 'react-native';
-=======
 import { AppState, Alert, Platform, Text, View } from 'react-native';
->>>>>>> d3018ae8 (feat(ui): tech-styled glass card with futuristic input fields)
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { LinearGradient } from 'expo-linear-gradient';
 import * as LocalAuthentication from 'expo-local-authentication';
@@ -41,28 +37,17 @@ export default function AppLock({ navigation }) {
           console.warn('Biometric availability check failed', error);
         }
       } finally {
-<<<<<<< HEAD
-        if (mountedRef.current) setChecking(false);
-=======
         if (mountedRef.current) {
           setChecking(false);
         }
->>>>>>> d3018ae8 (feat(ui): tech-styled glass card with futuristic input fields)
       }
     })();
   }, []);
 
   useEffect(() => {
-<<<<<<< HEAD
-    if (!isFocused || checking || !available || !enrolled) return;
-    const timeout = setTimeout(() => {
-      if (!promptingRef.current) promptAuth();
-    }, 250);
-    return () => clearTimeout(timeout);
-  }, [isFocused, checking, available, enrolled, promptAuth]);
-
-=======
-    if (!isFocused || !available || !enrolled) return;
+    if (!isFocused || checking || !available || !enrolled) {
+      return undefined;
+    }
 
     const timer = setTimeout(() => {
       if (!promptingRef.current) {
@@ -71,9 +56,8 @@ export default function AppLock({ navigation }) {
     }, 250);
 
     return () => clearTimeout(timer);
-  }, [isFocused, available, enrolled, promptAuth]);
+  }, [isFocused, checking, available, enrolled, promptAuth]);
 
->>>>>>> d3018ae8 (feat(ui): tech-styled glass card with futuristic input fields)
   useEffect(() => {
     const sub = AppState.addEventListener('change', (state) => {
       if (state === 'active') {
@@ -86,17 +70,16 @@ export default function AppLock({ navigation }) {
 
   const promptAuth = useCallback(async () => {
     try {
-      if (promptingRef.current || checking) return;
+      if (promptingRef.current || checking) {
+        return;
+      }
+
       promptingRef.current = true;
 
       if (!available || !enrolled) {
         Alert.alert(
           'Biometrics unavailable',
-<<<<<<< HEAD
           'Enable Face ID or Touch ID in your device settings to unlock HustleLedger.',
-=======
-          'Set up Face ID or Touch ID in your system settings to unlock HustleLedger.'
->>>>>>> d3018ae8 (feat(ui): tech-styled glass card with futuristic input fields)
         );
         return;
       }
@@ -108,7 +91,9 @@ export default function AppLock({ navigation }) {
         requireConfirmation: false,
       });
 
-      if (!mountedRef.current) return;
+      if (!mountedRef.current) {
+        return;
+      }
 
       if (result.success) {
         setTimeout(() => {
@@ -121,62 +106,11 @@ export default function AppLock({ navigation }) {
       if (__DEV__) {
         console.warn('Biometric authentication failed', error);
       }
-<<<<<<< HEAD
-      Alert.alert('Error', 'Could not start authentication.');
-    } finally {
-      promptingRef.current = false;
-    }
-  }, [available, checking, enrolled, navigation]);
-
-  return (
-    <LinearGradient
-      colors={[colors.bg, colors.bgSecondary ?? colors.bg]}
-      start={{ x: 0, y: 0 }}
-      end={{ x: 1, y: 1 }}
-      style={{ flex: 1 }}
-    >
-      <SafeAreaView style={{ flex: 1, padding: spacing(3) }}>
-        <View
-          style={{ flex: 1, justifyContent: 'center', gap: spacing(2) }}
-          accessibilityLabel="Biometric unlock"
-          accessibilityRole="summary"
-        >
-          <Text
-            style={{
-              color: colors.text,
-              fontSize: 22,
-              fontWeight: '700',
-              textAlign: 'center',
-            }}
-            allowFontScaling
-          >
-            Secure Command Center
-          </Text>
-          <Text
-            style={{
-              color: colors.subtext ?? 'rgba(231, 236, 255, 0.76)',
-              textAlign: 'center',
-              lineHeight: 20,
-            }}
-            allowFontScaling
-          >
-            Authenticate with Face ID to resume your AI-guided wealth strategy.
-          </Text>
-          <HLButton
-            title={checking ? 'Preparing…' : 'Unlock'}
-            onPress={promptAuth}
-            accessibilityLabel="Unlock HustleLedger"
-            disabled={checking}
-          />
-        </View>
-      </SafeAreaView>
-    </LinearGradient>
-=======
       Alert.alert('Error', 'Could not start authentication. Please try again.');
     } finally {
       promptingRef.current = false;
     }
-  }, [available, enrolled, navigation]);
+  }, [available, checking, enrolled, navigation]);
 
   const helperText = !available
     ? 'Biometric hardware is not available on this device.'
@@ -187,17 +121,17 @@ export default function AppLock({ navigation }) {
   return (
     <SafeAreaView style={{ flex: 1, backgroundColor: colors.bg }}>
       <LinearGradient
-        colors={[colors.bg, colors.bgSecondary]}
+        colors={[colors.bg, colors.bgSecondary ?? colors.bg]}
         start={{ x: 0, y: 0 }}
         end={{ x: 1, y: 1 }}
         style={{ flex: 1, padding: spacing(3), justifyContent: 'center' }}
       >
         <View style={{ gap: spacing(2) }}>
-          <Text style={{ color: colors.text, fontSize: 24, fontWeight: '700' }}>
+          <Text style={{ color: colors.text, fontSize: 24, fontWeight: '700' }} allowFontScaling>
             Authenticate to continue
           </Text>
           {!checking && (
-            <Text style={{ color: colors.subtext, fontSize: 15, lineHeight: 20 }}>
+            <Text style={{ color: colors.subtext, fontSize: 15, lineHeight: 20 }} allowFontScaling>
               {helperText}
             </Text>
           )}
@@ -210,6 +144,5 @@ export default function AppLock({ navigation }) {
         </View>
       </LinearGradient>
     </SafeAreaView>
->>>>>>> d3018ae8 (feat(ui): tech-styled glass card with futuristic input fields)
   );
 }

--- a/app/screens/SignIn.js
+++ b/app/screens/SignIn.js
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import {
   KeyboardAvoidingView,
   Platform,
@@ -6,6 +6,7 @@ import {
   Text as RNText,
   ScrollView,
   Pressable,
+  StyleSheet,
 } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { LinearGradient } from 'expo-linear-gradient';
@@ -38,7 +39,8 @@ export default function SignIn({ navigation }) {
   const [loading, setLoading] = useState(false);
   const [focusedField, setFocusedField] = useState(null);
 
-  const subtextColor = colors.subtext ?? (isDark ? 'rgba(231, 236, 255, 0.76)' : 'rgba(22, 30, 62, 0.72)');
+  const subtextColor =
+    colors.subtext ?? (isDark ? 'rgba(231, 236, 255, 0.76)' : 'rgba(22, 30, 62, 0.72)');
   const cardBorder = colors.cardBorder ?? 'rgba(130, 115, 255, 0.36)';
   const dangerColor = colors.danger ?? '#FF6F91';
   const gradientStops = isDark
@@ -84,13 +86,6 @@ export default function SignIn({ navigation }) {
     }
   };
 
-  const inputTheme = {
-    colors: {
-      onSurfaceVariant: subtextColor,
-      primary: colors.accent1,
-    },
-  };
-
   const badgeBackground = isDark ? 'rgba(12, 16, 48, 0.45)' : 'rgba(240, 244, 255, 0.6)';
   const secondaryLinkBg = isDark ? 'rgba(12, 16, 48, 0.24)' : 'rgba(247, 249, 255, 0.72)';
   const secondaryLinkText = isDark ? '#A18CFF' : '#5B4FE6';
@@ -118,152 +113,175 @@ export default function SignIn({ navigation }) {
               : ['rgba(95, 136, 255, 0.12)', 'transparent', 'rgba(101, 231, 254, 0.18)']
           }
         />
-
-            <GlassCard accessibilityLabel="Sign in to HustleLedger command deck">
-              <LinearGradient
-                colors={[`${colors.accent1}22`, `${colors.accent2}11`]}
-                start={{ x: 0, y: 0 }}
-                end={{ x: 1, y: 1 }}
-                style={{
-                  borderRadius: radii.lg,
-                  padding: spacing(1.75),
-                  marginBottom: spacing(2.5),
-                  backgroundColor: 'rgba(255,255,255,0.04)',
-                }}
-              >
-                <Text style={{ color: colors.subtext, fontSize: 13, lineHeight: 18 }}>
-                  HustleLedger syncs your accounts in real time with our AI engine. Banking-grade encryption keeps your data safe.
+        <SafeAreaView style={styles.flex}>
+          <ScrollView
+            contentContainerStyle={{ flexGrow: 1, padding: spacing(3), paddingBottom: spacing(5) }}
+            keyboardShouldPersistTaps="handled"
+          >
+            <View style={styles.contentWrapper}>
+              <View style={styles.heroArea}>
+                <View
+                  style={[
+                    styles.badgeGlow,
+                    { shadowColor: colors.accent2, backgroundColor: badgeBackground },
+                  ]}
+                >
+                  <Chip
+                    mode="outlined"
+                    style={[
+                      styles.badge,
+                      { borderColor: colors.accent2, backgroundColor: badgeBackground },
+                    ]}
+                    textStyle={{ color: colors.accent2, fontWeight: '600' }}
+                    accessibilityLabel="AI wealth concierge badge"
+                  >
+                    AI Wealth Concierge
+                  </Chip>
+                </View>
+                <RNText style={[styles.brandTitle, { color: colors.text }]} allowFontScaling>
+                  HustleLedger
+                </RNText>
+                <Text style={[styles.heroHeadline, { color: colors.text }]} allowFontScaling>
+                  Welcome back, creator.
+                </Text>
+                <Text
+                  style={[styles.heroDescription, { color: subtextColor }]}
+                  allowFontScaling
+                >
+                  Authenticate to orchestrate cash streams, automate savings, and keep every hustle aligned with your mission.
                 </Text>
               </View>
 
-              <View style={{ marginBottom: spacing(2) }}>
-                <View
-                  style={{
-                    borderRadius: radii.md,
-                    backgroundColor: colors.inputBackground,
-                    borderWidth: 1,
-                    borderColor:
+              <GlassCard accessibilityLabel="Sign in to HustleLedger command deck">
+                <LinearGradient
+                  colors={[`${colors.accent1}22`, `${colors.accent2}11`]}
+                  start={{ x: 0, y: 0 }}
+                  end={{ x: 1, y: 1 }}
+                  style={styles.helperGradient}
+                >
+                  <Text style={{ color: subtextColor, fontSize: 13, lineHeight: 18 }} allowFontScaling>
+                    HustleLedger syncs your accounts in real time with our AI engine. Banking-grade encryption keeps your data safe.
+                  </Text>
+                </LinearGradient>
+
+                <View style={{ marginBottom: spacing(2) }}>
+                  <View
+                    style={{
+                      borderRadius: radii.md,
+                      backgroundColor: colors.inputBackground,
+                      borderWidth: 1,
+                      borderColor:
+                        focusedField === 'email' ? `${colors.accent2}88` : colors.cardOutline,
+                      overflow: 'hidden',
+                    }}
+                  >
+                    <TextInput
+                      label="Your Access ID"
+                      value={email}
+                      onChangeText={setEmail}
+                      autoCapitalize="none"
+                      keyboardType="email-address"
+                      onFocus={() => handleFocus('email')}
+                      onBlur={handleBlur}
+                      mode="flat"
+                      left={
+                        <TextInput.Icon
+                          icon="email-outline"
+                          color={focusedField === 'email' ? colors.accent2 : colors.subtext}
+                        />
+                      }
+                      textColor={colors.text}
+                      style={{ backgroundColor: 'transparent' }}
+                      contentStyle={{ fontSize: 16 }}
+                      underlineColor="transparent"
+                      activeUnderlineColor="transparent"
+                      theme={{ colors: { onSurfaceVariant: colors.subtext } }}
+                      accessibilityLabel="Enter your email"
+                    />
+                  </View>
+                  <LinearGradient
+                    colors={
                       focusedField === 'email'
-                        ? `${colors.accent2}88`
-                        : colors.cardOutline,
-                    overflow: 'hidden',
-                  }}
-                >
-                  <TextInput
-                    label="Your Access ID"
-                    value={email}
-                    onChangeText={setEmail}
-                    autoCapitalize="none"
-                    keyboardType="email-address"
-                    onFocus={() => handleFocus('email')}
-                    onBlur={handleBlur}
-                    mode="flat"
-                    left={
-                      <TextInput.Icon
-                        icon="email-outline"
-                        color={focusedField === 'email' ? colors.accent2 : colors.subtext}
-                      />
+                        ? [colors.accent1, colors.accent2]
+                        : ['rgba(161, 140, 255, 0.35)', 'rgba(88, 213, 247, 0.35)']
                     }
-                    textColor={colors.text}
-                    style={{ backgroundColor: 'transparent' }}
-                    contentStyle={{ fontSize: 16 }}
-                    underlineColor="transparent"
-                    activeUnderlineColor="transparent"
-                    theme={{ colors: { onSurfaceVariant: colors.subtext } }}
-                    accessibilityLabel="Enter your email"
+                    start={{ x: 0, y: 0 }}
+                    end={{ x: 1, y: 0 }}
+                    style={{
+                      height: 3,
+                      borderRadius: 999,
+                      marginTop: spacing(0.5),
+                      opacity: focusedField === 'email' ? 1 : 0.5,
+                    }}
                   />
                 </View>
-                <LinearGradient
-                  colors={
-                    focusedField === 'email'
-                      ? [colors.accent1, colors.accent2]
-                      : ['rgba(161, 140, 255, 0.35)', 'rgba(88, 213, 247, 0.35)']
-                  }
-                  start={{ x: 0, y: 0 }}
-                  end={{ x: 1, y: 0 }}
-                  style={{
-                    height: 3,
-                    borderRadius: 999,
-                    marginTop: spacing(0.5),
-                    opacity: focusedField === 'email' ? 1 : 0.5,
-                  }}
-                />
-              </View>
 
-              <View style={{ marginBottom: spacing(1.5) }}>
-                <View
-                  style={{
-                    borderRadius: radii.md,
-                    backgroundColor: colors.inputBackground,
-                    borderWidth: 1,
-                    borderColor:
+                <View style={{ marginBottom: spacing(1.5) }}>
+                  <View
+                    style={{
+                      borderRadius: radii.md,
+                      backgroundColor: colors.inputBackground,
+                      borderWidth: 1,
+                      borderColor:
+                        focusedField === 'password'
+                          ? `${colors.accent1}88`
+                          : cardBorder,
+                      overflow: 'hidden',
+                    }}
+                  >
+                    <TextInput
+                      label="Secure Key"
+                      value={pw}
+                      onChangeText={setPw}
+                      secureTextEntry
+                      textContentType="oneTimeCode"
+                      onFocus={() => handleFocus('password')}
+                      onBlur={handleBlur}
+                      mode="flat"
+                      left={
+                        <TextInput.Icon
+                          icon="lock-outline"
+                          color={
+                            focusedField === 'password' ? colors.accent1 : colors.subtext
+                          }
+                        />
+                      }
+                      textColor={colors.text}
+                      style={{ backgroundColor: 'transparent' }}
+                      contentStyle={{ fontSize: 16 }}
+                      underlineColor="transparent"
+                      activeUnderlineColor="transparent"
+                      theme={{ colors: { onSurfaceVariant: colors.subtext } }}
+                      accessibilityLabel="Enter your password"
+                    />
+                  </View>
+                  <LinearGradient
+                    colors={
                       focusedField === 'password'
-                        ? `${colors.accent1}88`
-                        : colors.cardBorder,
-                    overflow: 'hidden',
-                  }}
-                >
-                  <TextInput
-                    label="Secure Key"
-                    value={pw}
-                    onChangeText={setPw}
-                    secureTextEntry
-                    textContentType="oneTimeCode"
-                    onFocus={() => handleFocus('password')}
-                    onBlur={handleBlur}
-                    mode="flat"
-                    left={
-                      <TextInput.Icon
-                        icon="lock-outline"
-                        color={focusedField === 'password' ? colors.accent1 : colors.subtext}
-                      />
+                        ? [colors.accent2, colors.accent1]
+                        : ['rgba(88, 213, 247, 0.35)', 'rgba(161, 140, 255, 0.35)']
                     }
-                    textColor={colors.text}
-                    style={{ backgroundColor: 'transparent' }}
-                    contentStyle={{ fontSize: 16 }}
-                    underlineColor="transparent"
-                    activeUnderlineColor="transparent"
-                    theme={{ colors: { onSurfaceVariant: colors.subtext } }}
-                    accessibilityLabel="Enter your password"
+                    start={{ x: 0, y: 0 }}
+                    end={{ x: 1, y: 0 }}
+                    style={{
+                      height: 3,
+                      borderRadius: 999,
+                      marginTop: spacing(0.5),
+                      opacity: focusedField === 'password' ? 1 : 0.5,
+                    }}
                   />
                 </View>
-                <LinearGradient
-                  colors={
-                    focusedField === 'password'
-                      ? [colors.accent2, colors.accent1]
-                      : ['rgba(88, 213, 247, 0.35)', 'rgba(161, 140, 255, 0.35)']
-                  }
-                  start={{ x: 0, y: 0 }}
-                  end={{ x: 1, y: 0 }}
-                  style={{
-                    height: 3,
-                    borderRadius: 999,
-                    marginTop: spacing(0.5),
-                    opacity: focusedField === 'password' ? 1 : 0.5,
-                  }}
-                />
-              </View>
 
-              <Pressable
-                onPress={() => navigation.navigate('ForgotPassword')}
-                style={{ alignSelf: 'flex-end', marginBottom: spacing(2) }}
-                accessibilityRole="button"
-                accessibilityLabel="Recover your secure key"
-              >
-                <Text style={{ color: colors.accent2, fontWeight: '600' }}>Forgot Secure Key?</Text>
-              </Pressable>
-
-                <TextInput
-                  label="Password"
-                  value={pw}
-                  onChangeText={setPw}
-                  secureTextEntry
-                  textContentType="oneTimeCode"
-                  style={styles.input}
-                  mode="flat"
-                  theme={inputTheme}
-                  accessibilityLabel="Password"
-                />
+                <Pressable
+                  onPress={() => navigation.navigate('ForgotPassword')}
+                  style={{ alignSelf: 'flex-end', marginBottom: spacing(2) }}
+                  accessibilityRole="button"
+                  accessibilityLabel="Recover your secure key"
+                >
+                  <Text style={{ color: colors.accent2, fontWeight: '600' }} allowFontScaling>
+                    Forgot Secure Key?
+                  </Text>
+                </Pressable>
 
                 {!!err && (
                   <Text style={{ color: dangerColor, marginBottom: spacing(1) }} allowFontScaling>
@@ -448,10 +466,6 @@ const styles = StyleSheet.create({
     padding: spacing(1.5),
     marginBottom: spacing(2),
     backgroundColor: 'rgba(255,255,255,0.04)',
-  },
-  input: {
-    marginBottom: spacing(1.5),
-    backgroundColor: 'transparent',
   },
   secondaryLink: {
     alignSelf: 'center',

--- a/app/screens/Welcome.js
+++ b/app/screens/Welcome.js
@@ -1,0 +1,182 @@
+import { useMemo } from 'react';
+import { SafeAreaView, StatusBar, View, Text, Pressable, StyleSheet } from 'react-native';
+import { useColors, spacing, radii, useIsDarkMode } from '../lib/theme';
+
+export default function Welcome({ navigation }) {
+  const colors = useColors();
+  const isDark = useIsDarkMode();
+
+  const containerStyle = useMemo(
+    () => [
+      styles.container,
+      { backgroundColor: colors.bgSecondary ?? colors.bg ?? '#0B0F23' },
+    ],
+    [colors.bg, colors.bgSecondary],
+  );
+
+  const cardStyle = useMemo(
+    () => [
+      styles.card,
+      {
+        backgroundColor: colors.card ?? 'rgba(12, 16, 48, 0.55)',
+        borderColor: colors.cardOutline ?? 'rgba(161, 140, 255, 0.16)',
+      },
+    ],
+    [colors.card, colors.cardOutline],
+  );
+
+  const onSignIn = () => {
+    navigation?.navigate?.('SignIn');
+  };
+
+  const onSignUp = () => {
+    navigation?.navigate?.('SignUp');
+  };
+
+  return (
+    <View style={[styles.background, { backgroundColor: colors.bg ?? '#02030A' }]}>
+      <StatusBar
+        barStyle={isDark ? 'light-content' : 'dark-content'}
+        backgroundColor="transparent"
+        translucent
+      />
+      <SafeAreaView style={styles.flex}>
+        <View style={containerStyle}>
+          <View
+            accessible
+            accessibilityRole="header"
+            accessibilityLabel="Welcome to HustleLedger"
+            style={styles.hero}
+          >
+            <Text style={[styles.title, { color: colors.text ?? '#F7F9FF' }]} allowFontScaling>
+              HustleLedger
+            </Text>
+            <Text
+              style={[
+                styles.subtitle,
+                { color: colors.subtext ?? 'rgba(231, 236, 255, 0.76)' },
+              ]}
+              allowFontScaling
+            >
+              Command your cashflow with real-time AI insights.
+            </Text>
+          </View>
+
+          <View style={cardStyle} accessibilityRole="summary">
+            <Text
+              style={[
+                styles.body,
+                { color: colors.text ?? '#F7F9FF' },
+              ]}
+              allowFontScaling
+            >
+              Connect accounts, automate savings, and unlock predictive forecasting tailored to creators.
+            </Text>
+          </View>
+
+          <View style={styles.actions}>
+            <Pressable
+              onPress={onSignIn}
+              accessibilityRole="button"
+              accessibilityLabel="Sign in to your HustleLedger account"
+              style={({ pressed }) => [
+                styles.primaryButton,
+                {
+                  backgroundColor: pressed
+                    ? `${colors.accent1 ?? '#A18CFF'}CC`
+                    : colors.accent1 ?? '#A18CFF',
+                },
+              ]}
+            >
+              <Text style={styles.primaryText} allowFontScaling>
+                Sign In
+              </Text>
+            </Pressable>
+
+            <Pressable
+              onPress={onSignUp}
+              accessibilityRole="button"
+              accessibilityLabel="Create a new HustleLedger account"
+              style={({ pressed }) => [
+                styles.secondaryButton,
+                {
+                  borderColor: colors.accent2 ?? '#58D5F7',
+                  backgroundColor: pressed
+                    ? `${colors.card ?? 'rgba(12, 16, 48, 0.55)'}DD`
+                    : colors.card ?? 'transparent',
+                },
+              ]}
+            >
+              <Text
+                style={[
+                  styles.secondaryText,
+                  { color: colors.accent2 ?? '#58D5F7' },
+                ]}
+                allowFontScaling
+              >
+                Create account
+              </Text>
+            </Pressable>
+          </View>
+        </View>
+      </SafeAreaView>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  flex: {
+    flex: 1,
+  },
+  background: {
+    flex: 1,
+  },
+  container: {
+    flex: 1,
+    padding: spacing(3),
+    justifyContent: 'space-between',
+  },
+  hero: {
+    gap: spacing(1),
+  },
+  title: {
+    fontSize: 40,
+    fontWeight: '800',
+  },
+  subtitle: {
+    fontSize: 16,
+    lineHeight: 22,
+  },
+  card: {
+    borderRadius: radii.lg,
+    borderWidth: 1,
+    padding: spacing(2),
+  },
+  body: {
+    fontSize: 15,
+    lineHeight: 20,
+  },
+  actions: {
+    gap: spacing(1.5),
+  },
+  primaryButton: {
+    borderRadius: radii.xl,
+    paddingVertical: spacing(1.75),
+    alignItems: 'center',
+  },
+  primaryText: {
+    fontSize: 16,
+    fontWeight: '700',
+    color: '#050510',
+  },
+  secondaryButton: {
+    borderRadius: radii.xl,
+    paddingVertical: spacing(1.75),
+    alignItems: 'center',
+    borderWidth: 1,
+  },
+  secondaryText: {
+    fontSize: 16,
+    fontWeight: '600',
+  },
+});

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,23 +1,23 @@
 import { createRequire } from 'node:module';
 import { FlatCompat } from '@eslint/eslintrc';
-
-const require = createRequire(import.meta.url);
-const recommendedConfig = require('./config/eslint/eslint-recommended.cjs');
 import reactPlugin from 'eslint-plugin-react';
 import reactHooksPlugin from 'eslint-plugin-react-hooks';
 import reactNativePlugin from 'eslint-plugin-react-native';
 
+const require = createRequire(import.meta.url);
+const recommendedConfig = require('./config/eslint/eslint-recommended.cjs');
+
 const compat = new FlatCompat({
   baseDirectory: import.meta.dirname,
-  recommendedConfig
+  recommendedConfig,
 });
 
 export default [
   {
-    ignores: ['node_modules/**', 'android/**', 'vendor/**']
+    ignores: ['node_modules/**', 'android/**', 'vendor/**'],
   },
   ...compat.config({
-    extends: ['eslint:recommended']
+    extends: ['eslint:recommended'],
   }),
   {
     files: ['**/*.{js,jsx,ts,tsx}'],
@@ -26,8 +26,8 @@ export default [
       sourceType: 'module',
       parserOptions: {
         ecmaFeatures: {
-          jsx: true
-        }
+          jsx: true,
+        },
       },
       globals: {
         __DEV__: 'readonly',
@@ -37,18 +37,18 @@ export default [
         requestAnimationFrame: 'readonly',
         require: 'readonly',
         setTimeout: 'readonly',
-        clearTimeout: 'readonly'
-      }
+        clearTimeout: 'readonly',
+      },
     },
     plugins: {
       react: reactPlugin,
       'react-hooks': reactHooksPlugin,
-      'react-native': reactNativePlugin
+      'react-native': reactNativePlugin,
     },
     settings: {
       react: {
-        version: 'detect'
-      }
+        version: 'detect',
+      },
     },
     rules: {
       'react/react-in-jsx-scope': 'off',
@@ -58,12 +58,23 @@ export default [
       'react-hooks/rules-of-hooks': 'error',
       'react-hooks/exhaustive-deps': 'warn',
       'react-native/no-unused-styles': 'error',
-      'react-native/no-inline-styles': 'off'
-    }
+      'react-native/no-inline-styles': 'off',
+    },
   },
   {
-<<<<<<< HEAD
-    files: ['.eslintrc.js', 'scripts/**/*.js'],
+    files: ['babel.config.js'],
+    languageOptions: {
+      sourceType: 'script',
+      globals: {
+        module: 'writable',
+        require: 'readonly',
+        __dirname: 'readonly',
+        process: 'readonly',
+      },
+    },
+  },
+  {
+    files: ['.eslintrc.js'],
     languageOptions: {
       sourceType: 'script',
       globals: {
@@ -76,21 +87,6 @@ export default [
     },
   },
   {
-    files: ['babel.config.js'],
-=======
-    files: ['babel.config.js', '.eslintrc.js'],
->>>>>>> d3018ae8 (feat(ui): tech-styled glass card with futuristic input fields)
-    languageOptions: {
-      sourceType: 'script',
-      globals: {
-        module: 'writable',
-        require: 'readonly',
-        __dirname: 'readonly',
-        process: 'readonly'
-      }
-    }
-  },
-  {
     files: ['scripts/**/*.js'],
     languageOptions: {
       sourceType: 'script',
@@ -98,9 +94,9 @@ export default [
         console: 'readonly',
         module: 'readonly',
         process: 'readonly',
-        require: 'readonly'
-      }
-    }
+        require: 'readonly',
+      },
+    },
   },
   {
     files: ['**/__tests__/**/*.{js,jsx,ts,tsx}', '**/*.test.{js,jsx,ts,tsx}'],
@@ -110,18 +106,18 @@ export default [
         it: 'readonly',
         expect: 'readonly',
         beforeEach: 'readonly',
-        jest: 'readonly'
-      }
-    }
+        jest: 'readonly',
+      },
+    },
   },
   {
     files: ['testing/**/*.mjs'],
     languageOptions: {
       sourceType: 'module',
       globals: {
-        URL: 'readonly'
-      }
-    }
+        URL: 'readonly',
+      },
+    },
   },
   {
     files: ['testing/**/*.cjs'],
@@ -132,8 +128,8 @@ export default [
         module: 'readonly',
         process: 'readonly',
         require: 'readonly',
-        __dirname: 'readonly'
-      }
-    }
-  }
+        __dirname: 'readonly',
+      },
+    },
+  },
 ];

--- a/package-lock.json
+++ b/package-lock.json
@@ -33,11 +33,13 @@
       },
       "devDependencies": {
         "@eslint/js": "^9.18.0",
+        "@testing-library/react-native": "^12.5.1",
         "cross-env": "^7.0.3",
         "eslint": "^9.18.0",
         "eslint-plugin-react": "^7.37.2",
         "eslint-plugin-react-hooks": "^5.2.0",
         "eslint-plugin-react-native": "^5.0.0",
+        "react-test-renderer": "^19.1.0",
         "rimraf": "^5.0.0"
       }
     },
@@ -2894,6 +2896,29 @@
       "version": "0.27.8",
       "license": "MIT"
     },
+    "node_modules/@testing-library/react-native": {
+      "version": "12.5.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/react-native/-/react-native-12.5.1.tgz",
+      "integrity": "sha512-PApr3f6DmSJF/EIiWYZfcBzuy6w7fK8TW4a6KfQHTeAcfZ6lADtRO7R0QM5WI+b7tJ33JvIPgzCg1MiuRz4v0g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "jest-matcher-utils": "^29.7.0",
+        "pretty-format": "^29.7.0",
+        "redent": "^3.0.0"
+      },
+      "peerDependencies": {
+        "jest": ">=28.0.0",
+        "react": ">=16.8.0",
+        "react-native": ">=0.59",
+        "react-test-renderer": ">=16.8.0"
+      },
+      "peerDependenciesMeta": {
+        "jest": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@types/estree": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
@@ -4235,6 +4260,16 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/diff-sequences": {
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-29.6.3.tgz",
+      "integrity": "sha512-EjePK1srD3P08o2j4f0ExnylqRs5B9tJjcp9t1krH2qRi8CCdsYfwe9JgSLurFBWwq4uOlipzfk5fHNvwFKr8Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
     "node_modules/doctrine": {
@@ -5946,6 +5981,16 @@
         "node": ">=0.8.19"
       }
     },
+    "node_modules/indent-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
+      "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/inflight": {
       "version": "1.0.6",
       "license": "ISC",
@@ -6454,6 +6499,47 @@
         "@pkgjs/parseargs": "^0.11.0"
       }
     },
+    "node_modules/jest-diff": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-29.7.0.tgz",
+      "integrity": "sha512-LMIgiIrhigmPrs03JHpxUh2yISK3vLFPkAodPeo0+BuF7wA2FoQbkEg1u8gBYBThncu7e1oEDUfIXVuTqLRUjw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^4.0.0",
+        "diff-sequences": "^29.6.3",
+        "jest-get-type": "^29.6.3",
+        "pretty-format": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-get-type": {
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-29.6.3.tgz",
+      "integrity": "sha512-zrteXnqYxfQh7l5FHyL38jL39di8H8rHoecLH3JNxH3BwOrBsNeabdap5e0I23lD4HHI8W5VFBZqG4Eaq5LNcw==",
+      "license": "MIT",
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-matcher-utils": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-29.7.0.tgz",
+      "integrity": "sha512-sBkD+Xi9DtcChsI3L3u0+N0opgPYnCRPtGcQYrgXmR+hmt/fYfWAL0xRXYU8eWOdfuLgBe0YCW3AFtnRLagq/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^4.0.0",
+        "jest-diff": "^29.7.0",
+        "jest-get-type": "^29.6.3",
+        "pretty-format": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
     "node_modules/jest-util": {
       "version": "29.7.0",
       "license": "MIT",
@@ -6507,13 +6593,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/jest-validate/node_modules/jest-get-type": {
-      "version": "29.6.3",
-      "license": "MIT",
-      "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
     "node_modules/jest-worker": {
@@ -7219,6 +7298,16 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.2.0.tgz",
       "integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/min-indent": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
+      "integrity": "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=4"
@@ -9511,6 +9600,34 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/react-test-renderer": {
+      "version": "19.1.0",
+      "resolved": "https://registry.npmjs.org/react-test-renderer/-/react-test-renderer-19.1.0.tgz",
+      "integrity": "sha512-jXkSl3CpvPYEF+p/eGDLB4sPoDX8pKkYvRl9+rR8HxLY0X04vW7hCm1/0zHoUSjPZ3bDa+wXWNTDVIw/R8aDVw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "react-is": "^19.1.0",
+        "scheduler": "^0.26.0"
+      },
+      "peerDependencies": {
+        "react": "^19.1.0"
+      }
+    },
+    "node_modules/redent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
+      "integrity": "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "indent-string": "^4.0.0",
+        "strip-indent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/reflect.getprototypeof": {
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/reflect.getprototypeof/-/reflect.getprototypeof-1.0.10.tgz",
@@ -10357,6 +10474,19 @@
       },
       "funding": {
         "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/strip-indent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
+      "integrity": "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "min-indent": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/strip-json-comments": {

--- a/package.json
+++ b/package.json
@@ -37,11 +37,13 @@
   },
   "devDependencies": {
     "@eslint/js": "^9.18.0",
+    "@testing-library/react-native": "^12.5.1",
     "cross-env": "^7.0.3",
     "eslint": "^9.18.0",
     "eslint-plugin-react": "^7.37.2",
     "eslint-plugin-react-hooks": "^5.2.0",
     "eslint-plugin-react-native": "^5.0.0",
+    "react-test-renderer": "^19.1.0",
     "rimraf": "^5.0.0"
   }
 }

--- a/testing/__mocks__/react-native/index.js
+++ b/testing/__mocks__/react-native/index.js
@@ -1,10 +1,86 @@
-export const Appearance = {
+/* eslint-env commonjs */
+/* globals module */
+
+const Appearance = {
   getColorScheme() {
     return 'dark';
   },
   addChangeListener() {
     return { remove() {} };
-  }
+  },
 };
 
-export default { Appearance };
+const View = 'View';
+const Text = 'Text';
+const Pressable = 'Pressable';
+const ScrollView = 'ScrollView';
+const KeyboardAvoidingView = 'KeyboardAvoidingView';
+const SafeAreaView = 'SafeAreaView';
+const TextInput = 'TextInput';
+const Switch = 'Switch';
+const Modal = 'Modal';
+const StatusBar = () => null;
+const StyleSheet = {
+  create(styles) {
+    return styles;
+  },
+  flatten(style) {
+    return style;
+  },
+  absoluteFillObject: {
+    position: 'absolute',
+    top: 0,
+    right: 0,
+    bottom: 0,
+    left: 0,
+  },
+};
+const Platform = {
+  OS: 'ios',
+  select(map) {
+    return map?.ios ?? map?.default;
+  },
+};
+const Alert = {
+  alert() {},
+};
+const AppState = {
+  addEventListener() {
+    return { remove() {} };
+  },
+};
+
+module.exports = {
+  Appearance,
+  View,
+  Text,
+  Pressable,
+  ScrollView,
+  KeyboardAvoidingView,
+  SafeAreaView,
+  StatusBar,
+  StyleSheet,
+  Platform,
+  Alert,
+  AppState,
+  TextInput,
+  Switch,
+  Modal,
+  default: {
+    Appearance,
+    View,
+    Text,
+    Pressable,
+    ScrollView,
+    KeyboardAvoidingView,
+    SafeAreaView,
+    StatusBar,
+    StyleSheet,
+    Platform,
+    Alert,
+    AppState,
+    TextInput,
+    Switch,
+    Modal,
+  },
+};

--- a/testing/__mocks__/react-native/package.json
+++ b/testing/__mocks__/react-native/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native",
   "version": "0.0.0-test",
-  "type": "module",
-  "exports": "./index.js"
+  "type": "commonjs",
+  "main": "./index.js"
 }

--- a/testing/react-native-loader.mjs
+++ b/testing/react-native-loader.mjs
@@ -1,8 +1,33 @@
+import { readFile } from 'node:fs/promises';
+import { fileURLToPath } from 'node:url';
+import { transform } from 'sucrase';
+
 const MOCK_URL = new URL('./__mocks__/react-native/index.js', import.meta.url).href;
 
 export async function resolve(specifier, context, defaultResolve) {
   if (specifier === 'react-native') {
     return { url: MOCK_URL, shortCircuit: true };
   }
-  return defaultResolve(specifier, context, defaultResolve);
+  try {
+    return await defaultResolve(specifier, context, defaultResolve);
+  } catch (error) {
+    if (specifier.startsWith('.') && !specifier.endsWith('.js')) {
+      return defaultResolve(`${specifier}.js`, context, defaultResolve);
+    }
+    throw error;
+  }
+}
+
+export async function load(url, context, defaultLoad) {
+  if (url.startsWith('file://') && url.includes('/app/')) {
+    const filename = fileURLToPath(url);
+    const source = await readFile(filename, 'utf8');
+
+    if (/\.js$/.test(filename)) {
+      const { code } = transform(source, { transforms: ['jsx'], jsxRuntime: 'automatic' });
+      return { format: 'module', source: code, shortCircuit: true }; 
+    }
+  }
+
+  return defaultLoad(url, context, defaultLoad);
 }

--- a/testing/register-mocks.cjs
+++ b/testing/register-mocks.cjs
@@ -1,0 +1,14 @@
+const Module = require('module');
+const path = require('node:path');
+
+const originalLoad = Module._load;
+const mockDirectory = path.resolve(__dirname, '__mocks__');
+const reactNativeEntry = path.join(mockDirectory, 'react-native', 'index.js');
+
+Module._load = function patchedLoad(request, parent, isMain) {
+  if (request === 'react-native') {
+    return originalLoad(reactNativeEntry, parent, isMain);
+  }
+
+  return originalLoad.apply(this, arguments);
+};

--- a/testing/run-tests.cjs
+++ b/testing/run-tests.cjs
@@ -8,9 +8,16 @@ const passthroughArgs = process.argv
 
 const loaderPath = path.resolve(__dirname, 'react-native-loader.mjs');
 
-const child = spawn(process.execPath, ['--test', '--loader', loaderPath, ...passthroughArgs], {
+const mockPath = path.resolve(__dirname, '__mocks__');
+const nodePath = process.env.NODE_PATH
+  ? `${mockPath}${path.delimiter}${process.env.NODE_PATH}`
+  : mockPath;
+
+const registerPath = path.resolve(__dirname, 'register-mocks.cjs');
+
+const child = spawn(process.execPath, ['--require', registerPath, '--test', '--loader', loaderPath, ...passthroughArgs], {
   stdio: 'inherit',
-  env: process.env,
+  env: { ...process.env, NODE_PATH: nodePath },
 });
 
 child.on('exit', (code) => process.exit(code ?? 0));


### PR DESCRIPTION
## Summary
- add a dedicated Welcome screen and expose it as the stack entry point
- resolve merge conflicts across SignIn/AppLock/theme and refresh palette tokens
- stand up a React Native testing harness with mocks/loader and a smoke test for Welcome navigation

## Testing
- npm run lint
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d9fe8f09e88322ad1d7403c9639fbd